### PR TITLE
optimized Uni V3 claim fee

### DIFF
--- a/contracts/e721-farms/uniswapV3/UniV3Farm.sol
+++ b/contracts/e721-farms/uniswapV3/UniV3Farm.sol
@@ -209,29 +209,20 @@ contract UniV3Farm is E721Farm, ExpirableFarm, OperableDeposit {
         _validateDeposit(msg.sender, _depositId);
         uint256 tokenId = depositToTokenId[_depositId];
 
-        address pm = nftContract;
-        (uint256 amt0, uint256 amt1) = IUniswapV3Utils(uniswapUtils).fees(pm, tokenId);
-        if (amt0 == 0 && amt1 == 0) {
-            revert NoFeeToClaim();
-        }
-        (uint256 amt0Recv, uint256 amt1Recv) = INFPM(pm).collect(
+        (uint256 amt0Recv, uint256 amt1Recv) = INFPM(nftContract).collect(
             INFPM.CollectParams({
                 tokenId: tokenId,
                 recipient: msg.sender,
-                amount0Max: uint128(amt0),
-                amount1Max: uint128(amt1)
+                amount0Max: type(uint128).max,
+                amount1Max: type(uint128).max
             })
         );
-        emit PoolFeeCollected(msg.sender, tokenId, amt0Recv, amt1Recv);
-    }
 
-    /// @notice Get the accrued uniswap fee for a deposit.
-    /// @return amount0 The amount of token0
-    /// @return amount1 The amount of token1
-    function computeUniswapFee(uint256 _tokenId) external view returns (uint256 amount0, uint256 amount1) {
-        // Validate token.
-        _getLiquidity(_tokenId);
-        return IUniswapV3Utils(uniswapUtils).fees(nftContract, _tokenId);
+        if (amt0Recv == 0 && amt1Recv == 0) {
+            revert NoFeeToClaim();
+        }
+
+        emit PoolFeeCollected(msg.sender, tokenId, amt0Recv, amt1Recv);
     }
 
     /// @notice A function to be called by Demeter Rewarder to get tokens and amounts associated with the farm's liquidity.

--- a/test/e721-farms/uniswapv3/UniV3Farm.t.sol
+++ b/test/e721-farms/uniswapv3/UniV3Farm.t.sol
@@ -24,6 +24,7 @@ import {E721FarmTest, E721FarmInheritTest} from "../E721Farm.t.sol";
 import {UniV3FarmDeployer} from "../../../contracts/e721-farms/uniswapV3/UniV3FarmDeployer.sol";
 import "../../features/ExpirableFarm.t.sol";
 import "../../utils/UpgradeUtil.t.sol";
+import "../../../contracts/e721-farms/uniswapV3/interfaces/IUniswapV3Utils.sol";
 
 import {VmSafe} from "forge-std/Vm.sol";
 
@@ -603,8 +604,10 @@ abstract contract ClaimUniswapFeeTest is UniV3FarmTest {
         _simulateSwap();
         uint256 _tokenId = UniV3Farm(lockupFarm).depositToTokenId(depositId);
 
-        vm.expectEmit(true, false, false, false, address(lockupFarm));
-        emit PoolFeeCollected(currentActor, _tokenId, 0, 0);
+        (uint256 amt0, uint256 amt1) = IUniswapV3Utils(UNISWAP_UTILS).fees(NFPM, _tokenId);
+
+        vm.expectEmit(address(lockupFarm));
+        emit PoolFeeCollected(currentActor, _tokenId, amt0, amt1);
 
         UniV3Farm(lockupFarm).claimUniswapFee(depositId);
     }

--- a/test/e721-farms/uniswapv3/UniV3Farm.t.sol
+++ b/test/e721-farms/uniswapv3/UniV3Farm.t.sol
@@ -602,10 +602,9 @@ abstract contract ClaimUniswapFeeTest is UniV3FarmTest {
         uint256 depositId = 1;
         _simulateSwap();
         uint256 _tokenId = UniV3Farm(lockupFarm).depositToTokenId(depositId);
-        (uint256 amount0, uint256 amount1) = UniV3Farm(lockupFarm).computeUniswapFee(_tokenId);
 
-        vm.expectEmit(address(lockupFarm));
-        emit PoolFeeCollected(currentActor, _tokenId, amount0, amount1);
+        vm.expectEmit(true, false, false, false, address(lockupFarm));
+        emit PoolFeeCollected(currentActor, _tokenId, 0, 0);
 
         UniV3Farm(lockupFarm).claimUniswapFee(depositId);
     }

--- a/test/e721-farms/uniswapv3/UniV3Farm.t.sol
+++ b/test/e721-farms/uniswapv3/UniV3Farm.t.sol
@@ -4,12 +4,17 @@ pragma solidity 0.8.16;
 // import contracts
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+
 import {
+    Farm,
     E721Farm,
     UniV3Farm,
     UniswapPoolData,
+    RewardTokenData,
     IUniswapV3Factory,
     IUniswapV3TickSpacing,
+    IUniswapV3Utils,
     INFPM,
     OperableDeposit
 } from "../../../contracts/e721-farms/uniswapV3/UniV3Farm.sol";
@@ -17,14 +22,14 @@ import {
     INFPMUtils,
     Position
 } from "../../../contracts/e721-farms/uniswapV3/interfaces/INonfungiblePositionManagerUtils.sol";
-import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import {UniV3FarmDeployer} from "../../../contracts/e721-farms/uniswapV3/UniV3FarmDeployer.sol";
+import {FarmRegistry} from "../../../contracts/FarmRegistry.sol";
 
 // import tests
 import {E721FarmTest, E721FarmInheritTest} from "../E721Farm.t.sol";
-import {UniV3FarmDeployer} from "../../../contracts/e721-farms/uniswapV3/UniV3FarmDeployer.sol";
-import "../../features/ExpirableFarm.t.sol";
-import "../../utils/UpgradeUtil.t.sol";
-import "../../../contracts/e721-farms/uniswapV3/interfaces/IUniswapV3Utils.sol";
+import {FarmTest, FarmInheritTest} from "../../Farm.t.sol";
+import {ExpirableFarmInheritTest} from "../../features/ExpirableFarm.t.sol";
+import {UpgradeUtil} from "../../utils/UpgradeUtil.t.sol";
 
 import {VmSafe} from "forge-std/Vm.sol";
 

--- a/test/e721-farms/uniswapv3/UniV3Farm.t.sol
+++ b/test/e721-farms/uniswapv3/UniV3Farm.t.sol
@@ -609,7 +609,13 @@ abstract contract ClaimUniswapFeeTest is UniV3FarmTest {
         vm.expectEmit(address(lockupFarm));
         emit PoolFeeCollected(currentActor, _tokenId, amt0, amt1);
 
+        uint256 amt0Before = IERC20(DAI).balanceOf(currentActor);
+        uint256 amt1Before = IERC20(USDCe).balanceOf(currentActor);
+
         UniV3Farm(lockupFarm).claimUniswapFee(depositId);
+
+        assertEq(amt0Before + amt0, IERC20(DAI).balanceOf(currentActor));
+        assertEq(amt1Before + amt1, IERC20(USDCe).balanceOf(currentActor));
     }
 }
 


### PR DESCRIPTION
For getting unclaimed accrued fees of a position to display in front-end we can do a static call on nft position manager's collect function with the required tokenId, amount0max and amount1max as uint128(max) (2^128 - 1).

Increase deposit or decrease deposit won't affect our new fee collection logic. reviewed it.