### PR TITLE
Audit Fixes: QS-1

### DIFF
--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -619,8 +619,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     function _updateFarmRewardData() internal virtual {
         uint256 time = _getRewardAccrualTimeElapsed();
         if (time > 0) {
-            // If farm is paused don't accrue any rewards,
-            // only update the lastFundUpdateTime.
+            // Accrue rewards if farm is active.
             if (isFarmActive()) {
                 uint256 numFunds = rewardFunds.length;
                 uint256 numRewards = rewardTokens.length;
@@ -645,7 +644,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
                 }
             }
         }
-        _updateLastRewardAccrualTime();
+        _updateLastRewardAccrualTime(); // Update the last reward accrual time.
     }
 
     /// @notice Function to setup the reward funds and initialize the farm global params during construction.

--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -801,6 +801,9 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @notice Get the time elapsed since the last reward accrual.
     /// @return time The time elapsed since the last reward accrual.
     function _getRewardAccrualTimeElapsed() internal view virtual returns (uint256) {
+        if (lastFundUpdateTime > block.timestamp) {
+            return 0;
+        }
         unchecked {
             return block.timestamp - lastFundUpdateTime;
         }

--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -796,7 +796,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @notice Get the time elapsed since the last reward accrual.
     /// @return time The time elapsed since the last reward accrual.
     function _getRewardAccrualTimeElapsed() internal view virtual returns (uint256) {
-        if (farmStartTime > block.timestamp) {
+        if (farmStartTime > block.timestamp || lastFundUpdateTime == 0) {
             return 0;
         }
         unchecked {

--- a/contracts/FarmStorage.sol
+++ b/contracts/FarmStorage.sol
@@ -44,6 +44,7 @@ abstract contract FarmStorage {
 
     uint256 public cooldownPeriod;
     uint256 public lastFundUpdateTime;
+    uint256 public farmStartTime;
     uint256 public totalDeposits;
 
     // Reward info.

--- a/contracts/e721-farms/uniswapV3/UniV3ActiveLiquidityFarm.sol
+++ b/contracts/e721-farms/uniswapV3/UniV3ActiveLiquidityFarm.sol
@@ -54,6 +54,7 @@ contract UniV3ActiveLiquidityFarm is UniV3Farm {
     /// @return time The time elapsed since the last reward accrual.
     /// @dev This function is overridden from Farm to incorporate reward distribution only for active liquidity.
     function _getRewardAccrualTimeElapsed() internal view override returns (uint256) {
+        if (farmStartTime > block.timestamp || lastSecondsInside == 0) return 0; // Farm has not started
         (,, uint32 secondsInside) =
             IUniswapV3PoolDerivedState(uniswapPool).snapshotCumulativesInside(tickLowerAllowed, tickUpperAllowed);
         return secondsInside - lastSecondsInside;

--- a/contracts/features/ExpirableFarm.sol
+++ b/contracts/features/ExpirableFarm.sol
@@ -52,7 +52,7 @@ abstract contract ExpirableFarm is Farm {
     /// @param _extensionDays The number of days to extend the farm. Example: 150 means 150 days.
     function extendFarmDuration(uint256 _extensionDays) external onlyOwner nonReentrant {
         _validateFarmOpen();
-        if (lastFundUpdateTime > block.timestamp) {
+        if (farmStartTime > block.timestamp) {
             revert FarmNotYetStarted();
         }
         if (_extensionDays < MIN_EXTENSION || _extensionDays > MAX_EXTENSION) {
@@ -73,13 +73,13 @@ abstract contract ExpirableFarm is Farm {
     ///      Adjusts the farm end time accordingly.
     /// @param _newStartTime The new farm start time.
     function updateFarmStartTime(uint256 _newStartTime) public virtual override onlyOwner {
-        uint256 _currentLastFundUpdateTime = lastFundUpdateTime;
+        uint256 _currentFarmStartTime = farmStartTime;
 
         super.updateFarmStartTime(_newStartTime);
 
-        farmEndTime = (_newStartTime > _currentLastFundUpdateTime)
-            ? farmEndTime + (_newStartTime - _currentLastFundUpdateTime)
-            : farmEndTime - (_currentLastFundUpdateTime - _newStartTime);
+        farmEndTime = (_newStartTime > _currentFarmStartTime)
+            ? farmEndTime + (_newStartTime - _currentFarmStartTime)
+            : farmEndTime - (_currentFarmStartTime - _newStartTime);
     }
 
     /// @notice Returns bool status if farm is open.

--- a/contracts/features/ExpirableFarm.sol
+++ b/contracts/features/ExpirableFarm.sol
@@ -73,13 +73,13 @@ abstract contract ExpirableFarm is Farm {
     ///      Adjusts the farm end time accordingly.
     /// @param _newStartTime The new farm start time.
     function updateFarmStartTime(uint256 _newStartTime) public virtual override onlyOwner {
-        uint256 _currentFarmStartTime = farmStartTime;
+        uint256 currentFarmStartTime = farmStartTime;
 
         super.updateFarmStartTime(_newStartTime);
 
-        farmEndTime = (_newStartTime > _currentFarmStartTime)
-            ? farmEndTime + (_newStartTime - _currentFarmStartTime)
-            : farmEndTime - (_currentFarmStartTime - _newStartTime);
+        farmEndTime = (_newStartTime > currentFarmStartTime)
+            ? farmEndTime + (_newStartTime - currentFarmStartTime)
+            : farmEndTime - (currentFarmStartTime - _newStartTime);
     }
 
     /// @notice Returns bool status if farm is open.

--- a/test/Farm.t.sol
+++ b/test/Farm.t.sol
@@ -135,6 +135,17 @@ abstract contract DepositTest is FarmTest {
             deposit(farm, lockup, 1e2);
         }
     }
+
+    function testFuzz_Deposit_Before_Farm_StartTime(bool lockup) public {
+        // Here time for rewards should be 0, hence, lastFundUpdateTime should be startTime itself
+        // and not the time when the deposit is made.
+        uint256 startTime = block.timestamp + 1 days;
+        address farm = createFarm(startTime, lockup);
+
+        deposit(farm, lockup, DEPOSIT_AMOUNT);
+
+        assertEq(Farm(farm).lastFundUpdateTime(), startTime);
+    }
 }
 
 abstract contract ClaimRewardsTest is FarmTest {

--- a/test/e721-farms/camelotV3/CamelotV3Farm.t.sol
+++ b/test/e721-farms/camelotV3/CamelotV3Farm.t.sol
@@ -373,7 +373,8 @@ abstract contract InitializeTest is CamelotV3FarmTest {
         assertEq(CamelotV3Farm(farmProxy).tickUpperAllowed(), TICK_UPPER);
         assertEq(CamelotV3Farm(farmProxy).camelotPool(), camelotPool);
         assertEq(CamelotV3Farm(farmProxy).owner(), address(this)); // changes to admin when called via deployer
-        assertEq(CamelotV3Farm(farmProxy).lastFundUpdateTime(), block.timestamp);
+        assertEq(CamelotV3Farm(farmProxy).farmStartTime(), block.timestamp);
+        assertEq(CamelotV3Farm(farmProxy).lastFundUpdateTime(), 0);
         assertEq(CamelotV3Farm(farmProxy).cooldownPeriod(), COOLDOWN_PERIOD_DAYS * 1 days);
         assertEq(CamelotV3Farm(farmProxy).farmId(), FARM_ID);
         assertEq(CamelotV3Farm(farmProxy).camelotV3Factory(), CAMELOT_V3_FACTORY);

--- a/test/e721-farms/uniswapv3/UniV3Farm.t.sol
+++ b/test/e721-farms/uniswapv3/UniV3Farm.t.sol
@@ -374,7 +374,8 @@ abstract contract InitializeTest is UniV3FarmTest {
         assertEq(UniV3Farm(farmProxy).tickUpperAllowed(), TICK_UPPER);
         assertEq(UniV3Farm(farmProxy).uniswapPool(), uniswapPool);
         assertEq(UniV3Farm(farmProxy).owner(), address(this)); // changes to admin when called via deployer
-        assertEq(UniV3Farm(farmProxy).lastFundUpdateTime(), block.timestamp);
+        assertEq(UniV3Farm(farmProxy).farmStartTime(), block.timestamp);
+        assertEq(UniV3Farm(farmProxy).lastFundUpdateTime(), 0);
         assertEq(UniV3Farm(farmProxy).cooldownPeriod(), COOLDOWN_PERIOD_DAYS * 1 days);
         assertEq(UniV3Farm(farmProxy).farmId(), FARM_ID);
         assertEq(UniV3Farm(farmProxy).uniV3Factory(), UNIV3_FACTORY);


### PR DESCRIPTION
-  This bug was introduced in https://github.com/Sperax/Demeter-Protocol/pull/21/
- Add `farmStartTime` in place of `lastFundUpdateTime`
- `_getRewardAccrualTimeElapsed` will return 0 if `block.timestamp > farmStartTime` or `lastFundUpdateTime = 0`
- Change logic when `lastFundUpdateTime` is updated. This is added to fix problems in UniV3ActiveFarm
- Fixed testcases for the changes
<img width="969" alt="Screenshot 2024-06-18 at 1 31 54 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/d22f7975-d9ad-45dd-9c51-97ce507f6db3">