### PR TITLE
Audit Fixes: QS-4

### DIFF
--- a/contracts/e721-farms/camelotV3/CamelotV3Farm.sol
+++ b/contracts/e721-farms/camelotV3/CamelotV3Farm.sol
@@ -29,6 +29,7 @@ import {Farm, E721Farm} from "../E721Farm.sol";
 import {ExpirableFarm} from "../../features/ExpirableFarm.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {INFPM, ICamelotV3Factory, ICamelotV3TickSpacing} from "./interfaces/ICamelotV3.sol";
 import {ICamelotV3NFPMUtils, Position} from "./interfaces/ICamelotV3NonfungiblePositionManagerUtils.sol";
 import {OperableDeposit} from "../../features/OperableDeposit.sol";
@@ -199,8 +200,8 @@ contract CamelotV3Farm is E721Farm, ExpirableFarm, OperableDeposit {
             INFPM.CollectParams({
                 tokenId: tokenId,
                 recipient: msg.sender,
-                amount0Max: uint128(amount0),
-                amount1Max: uint128(amount1)
+                amount0Max: SafeCast.toUint128(amount0),
+                amount1Max: SafeCast.toUint128(amount1)
             })
         );
     }

--- a/contracts/e721-farms/uniswapV3/UniV3Farm.sol
+++ b/contracts/e721-farms/uniswapV3/UniV3Farm.sol
@@ -33,6 +33,7 @@ import {INFPM, IUniswapV3Factory, IUniswapV3TickSpacing} from "./interfaces/IUni
 import {INFPMUtils, Position} from "./interfaces/INonfungiblePositionManagerUtils.sol";
 import {OperableDeposit} from "../../features/OperableDeposit.sol";
 import {TokenUtils} from "../../utils/TokenUtils.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 // Defines the Uniswap pool init data for constructor.
 // tokenA - Address of tokenA.
@@ -200,8 +201,8 @@ contract UniV3Farm is E721Farm, ExpirableFarm, OperableDeposit {
             INFPM.CollectParams({
                 tokenId: tokenId,
                 recipient: msg.sender,
-                amount0Max: uint128(amount0),
-                amount1Max: uint128(amount1)
+                amount0Max: SafeCast.toUint128(amount0),
+                amount1Max: SafeCast.toUint128(amount1)
             })
         );
     }

--- a/contracts/utils/TokenUtils.sol
+++ b/contracts/utils/TokenUtils.sol
@@ -29,6 +29,7 @@ import {IUniswapV3PoolState} from "../e721-farms/uniswapV3/interfaces/IUniswapV3
 import {IUniswapV3Utils} from "../e721-farms/uniswapV3/interfaces/IUniswapV3Utils.sol";
 import {ICamelotV3Utils} from "../e721-farms/camelotV3/interfaces/ICamelotV3Utils.sol";
 import {ICamelotV3PoolState} from "../e721-farms/camelotV3/interfaces/ICamelotV3.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /// @title Utility library to calculate token amounts for different farms based on the farm's liquidity.
 /// @author Sperax Foundation.
@@ -81,8 +82,9 @@ library TokenUtils {
         oldestObservationSecondsAgo = oldestObservationSecondsAgo < MA_PERIOD ? MA_PERIOD : oldestObservationSecondsAgo;
         (int24 timeWeightedAverageTick,) = IUniswapV3Utils(_uniUtils).consult(_uniPool, oldestObservationSecondsAgo);
         uint160 sqrtPriceX96 = IUniswapV3Utils(_uniUtils).getSqrtRatioAtTick(timeWeightedAverageTick);
-        (amounts[0], amounts[1]) =
-            IUniswapV3Utils(_uniUtils).getAmountsForLiquidity(sqrtPriceX96, _tickLower, _tickUpper, uint128(_liquidity));
+        (amounts[0], amounts[1]) = IUniswapV3Utils(_uniUtils).getAmountsForLiquidity(
+            sqrtPriceX96, _tickLower, _tickUpper, SafeCast.toUint128(_liquidity)
+        );
     }
 
     /// @notice Get token amounts for Camelot V3 farm based on the farm's liquidity.
@@ -106,7 +108,7 @@ library TokenUtils {
         tokens[1] = ICamelotV3PoolState(_camelotPool).token1();
         (uint160 sqrtPriceX96,,,,,,,) = ICamelotV3PoolState(_camelotPool).globalState();
         (amounts[0], amounts[1]) = ICamelotV3Utils(_camelotUtils).getAmountsForLiquidity(
-            sqrtPriceX96, _tickLower, _tickUpper, uint128(_liquidity)
+            sqrtPriceX96, _tickLower, _tickUpper, SafeCast.toUint128(_liquidity)
         );
     }
 }

--- a/test/e721-farms/camelotV3/CamelotV3Farm.t.sol
+++ b/test/e721-farms/camelotV3/CamelotV3Farm.t.sol
@@ -25,6 +25,7 @@ import {
 import {ICamelotV3PoolState} from "../../../contracts/e721-farms/camelotV3/interfaces/ICamelotV3.sol";
 import {CamelotV3FarmDeployer} from "../../../contracts/e721-farms/camelotV3/CamelotV3FarmDeployer.sol";
 import {FarmRegistry} from "../../../contracts/FarmRegistry.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 // import tests
 import {E721FarmTest, E721FarmInheritTest} from "../E721Farm.t.sol";
@@ -220,7 +221,7 @@ abstract contract CamelotV3FarmTest is E721FarmTest {
             INFPM(NFPM).decreaseLiquidity(
                 INFPM.DecreaseLiquidityParams({
                     tokenId: tokenId,
-                    liquidity: uint128(liquidity),
+                    liquidity: SafeCast.toUint128(liquidity),
                     amount0Min: 0,
                     amount1Min: 0,
                     deadline: block.timestamp
@@ -714,8 +715,8 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         farm = isLockupFarm ? lockupFarm : nonLockupFarm;
         depositSetupFn(farm, false);
 
-        uint128 oldLiquidity = uint128(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity);
-        uint128 liquidityToWithdraw = uint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
+        uint128 oldLiquidity = SafeCast.toUint128(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity);
+        uint128 liquidityToWithdraw = SafeCast.toUint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
         assertEq(currentActor, user);
         assert(DAI < USDCe); // To ensure that the first token is DAI and the second is USDCe
 
@@ -773,8 +774,8 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         farm = isLockupFarm ? lockupFarm : nonLockupFarm;
         depositSetupFn(farm, false);
 
-        uint128 oldLiquidity = uint128(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity);
-        uint128 liquidityToWithdraw = uint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
+        uint128 oldLiquidity = SafeCast.toUint128(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity);
+        uint128 liquidityToWithdraw = SafeCast.toUint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
         assertEq(currentActor, user);
         assert(DAI < USDCe); // To ensure that the first token is DAI and the second is USDCe
 
@@ -843,7 +844,7 @@ abstract contract GetTokenAmountsTest is CamelotV3FarmTest {
             sqrtRatioX96,
             CamelotV3Farm(lockupFarm).tickLowerAllowed(),
             CamelotV3Farm(lockupFarm).tickUpperAllowed(),
-            uint128(
+            SafeCast.toUint128(
                 CamelotV3Farm(lockupFarm).getRewardFundInfo(CamelotV3Farm(lockupFarm).COMMON_FUND_ID()).totalLiquidity
             )
         );

--- a/test/e721-farms/uniswapv3/UniV3Farm.t.sol
+++ b/test/e721-farms/uniswapv3/UniV3Farm.t.sol
@@ -25,6 +25,7 @@ import {
 } from "../../../contracts/e721-farms/uniswapV3/interfaces/INonfungiblePositionManagerUtils.sol";
 import {UniV3FarmDeployer} from "../../../contracts/e721-farms/uniswapV3/UniV3FarmDeployer.sol";
 import {FarmRegistry} from "../../../contracts/FarmRegistry.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 // import tests
 import {E721FarmTest, E721FarmInheritTest} from "../E721Farm.t.sol";
@@ -206,7 +207,7 @@ abstract contract UniV3FarmTest is E721FarmTest {
             INFPM(NFPM).decreaseLiquidity(
                 INFPM.DecreaseLiquidityParams({
                     tokenId: tokenId,
-                    liquidity: uint128(liquidity),
+                    liquidity: SafeCast.toUint128(liquidity),
                     amount0Min: 0,
                     amount1Min: 0,
                     deadline: block.timestamp
@@ -657,8 +658,8 @@ abstract contract DecreaseDepositTest is UniV3FarmTest {
         farm = isLockupFarm ? lockupFarm : nonLockupFarm;
         depositSetupFn(farm, false);
 
-        uint128 oldLiquidity = uint128(UniV3Farm(farm).getDepositInfo(depositId).liquidity);
-        uint128 liquidityToWithdraw = uint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
+        uint128 oldLiquidity = SafeCast.toUint128(UniV3Farm(farm).getDepositInfo(depositId).liquidity);
+        uint128 liquidityToWithdraw = SafeCast.toUint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
         assertEq(currentActor, user);
         assert(DAI < USDCe); // To ensure that the first token is DAI and the second is USDCe
 


### PR DESCRIPTION
- We have added Openzeppelin SafeCase in all places where we were doing uint256->uint128 typecasting. 
<img width="942" alt="Screenshot 2024-06-18 at 2 35 26 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/9d2c4f5d-332e-4cd8-8fbc-d45f935fd534">
