### PR TITLE
Audit Fixes: QS-9

### DIFF
--- a/contracts/FarmRegistry.sol
+++ b/contracts/FarmRegistry.sol
@@ -39,7 +39,7 @@ contract FarmRegistry is OwnableUpgradeable {
     mapping(address => bool) public farmRegistered;
     mapping(address => bool) public deployerRegistered;
     // List of deployers for which fee won't be charged.
-    mapping(address => bool) public isPrivilegedDeployer;
+    mapping(address => bool) public isPrivilegedUser;
 
     // Events.
     event FarmRegistered(address indexed farm, address indexed creator, address indexed deployer);
@@ -112,16 +112,16 @@ contract FarmRegistry is OwnableUpgradeable {
         emit FarmDeployerUpdated(deployer, false);
     }
 
-    /// @notice Function to add/ remove privileged deployer.
-    /// @param _deployer Deployer(address) to add to privileged deployers list.
+    /// @notice Function to add/remove privileged Users.
+    /// @param _userAddress User Address for which privilege is to be updated.
     /// @param _privilege Privilege(bool) whether true or false.
     /// @dev Only callable by the owner.
-    function updatePrivilege(address _deployer, bool _privilege) external onlyOwner {
-        if (isPrivilegedDeployer[_deployer] == _privilege) {
+    function updatePrivilege(address _userAddress, bool _privilege) external onlyOwner {
+        if (isPrivilegedUser[_userAddress] == _privilege) {
             revert PrivilegeSameAsDesired();
         }
-        isPrivilegedDeployer[_deployer] = _privilege;
-        emit PrivilegeUpdated(_deployer, _privilege);
+        isPrivilegedUser[_userAddress] = _privilege;
+        emit PrivilegeUpdated(_userAddress, _privilege);
     }
 
     /// @notice Get list of registered deployer.
@@ -141,7 +141,7 @@ contract FarmRegistry is OwnableUpgradeable {
     /// @return Returns FeeReceiver, feeToken address, feeTokenAmt and extensionFeePerDay.
     /// @dev It returns fee amount as 0 if deployer account is privileged.
     function getFeeParams(address _deployerAccount) external view returns (address, address, uint256, uint256) {
-        if (isPrivilegedDeployer[_deployerAccount]) {
+        if (isPrivilegedUser[_deployerAccount]) {
             return (feeReceiver, feeToken, 0, 0);
         }
         return (feeReceiver, feeToken, feeAmount, extensionFeePerDay);

--- a/contracts/FarmRegistry.sol
+++ b/contracts/FarmRegistry.sol
@@ -112,16 +112,16 @@ contract FarmRegistry is OwnableUpgradeable {
         emit FarmDeployerUpdated(deployer, false);
     }
 
-    /// @notice Function to add/remove privileged Users.
-    /// @param _userAddress User Address for which privilege is to be updated.
+    /// @notice Function to add/remove privileged User.
+    /// @param _user User Address for which privilege is to be updated.
     /// @param _privilege Privilege(bool) whether true or false.
     /// @dev Only callable by the owner.
-    function updatePrivilege(address _userAddress, bool _privilege) external onlyOwner {
-        if (isPrivilegedUser[_userAddress] == _privilege) {
+    function updatePrivilege(address _user, bool _privilege) external onlyOwner {
+        if (isPrivilegedUser[_user] == _privilege) {
             revert PrivilegeSameAsDesired();
         }
-        isPrivilegedUser[_userAddress] = _privilege;
-        emit PrivilegeUpdated(_userAddress, _privilege);
+        isPrivilegedUser[_user] = _privilege;
+        emit PrivilegeUpdated(_user, _privilege);
     }
 
     /// @notice Get list of registered deployer.
@@ -137,11 +137,11 @@ contract FarmRegistry is OwnableUpgradeable {
     }
 
     /// @notice Get all the fee parameters for creating farm.
-    /// @param _deployerAccount The account creating the farm.
+    /// @param _user The account creating the farm.
     /// @return Returns FeeReceiver, feeToken address, feeTokenAmt and extensionFeePerDay.
     /// @dev It returns fee amount as 0 if deployer account is privileged.
-    function getFeeParams(address _deployerAccount) external view returns (address, address, uint256, uint256) {
-        if (isPrivilegedUser[_deployerAccount]) {
+    function getFeeParams(address _user) external view returns (address, address, uint256, uint256) {
+        if (isPrivilegedUser[_user]) {
             return (feeReceiver, feeToken, 0, 0);
         }
         return (feeReceiver, feeToken, feeAmount, extensionFeePerDay);

--- a/contracts/interfaces/IFarmRegistry.sol
+++ b/contracts/interfaces/IFarmRegistry.sol
@@ -11,5 +11,5 @@ interface IFarmRegistry {
         view
         returns (address feeFeceiver, address feeToken, uint256 feeAmount, uint256 extensionFeePerDay);
 
-    function isPrivilegedDeployer(address _user) external view returns (bool);
+    function isPrivilegedUser(address _user) external view returns (bool);
 }

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -72,7 +72,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     uint256 public constant REWARD_PERIOD = 1 weeks;
     uint256 public constant DENOMINATOR = 100;
     uint256 public constant ONE_YEAR = 365 days;
-    address public REWARD_TOKEN; // solhint-disable-line var-name-mixedcase.
+    address public REWARD_TOKEN; // solhint-disable-line var-name-mixedcase
     uint256 public totalRewardRate; // Rewards emitted per second for all the farms from this rewarder.
     address public rewarderFactory;
     // farm -> FarmRewardConfig.

--- a/test/FarmRegistry.t.sol
+++ b/test/FarmRegistry.t.sol
@@ -207,7 +207,7 @@ contract UpdatePrivilegeTest is FarmRegistryTest {
         vm.expectEmit(address(registry));
         emit PrivilegeUpdated(owner, true);
         FarmRegistry(registry).updatePrivilege(owner, true);
-        assertEq(FarmRegistry(registry).isPrivilegedDeployer(owner), true);
+        assertEq(FarmRegistry(registry).isPrivilegedUser(owner), true);
 
         // Test getFeeParams
         (address _feeReceiver, address _feeToken, uint256 _feeAmount, uint256 _extensionFeePerDay) =

--- a/tests/test_farm_factory.py
+++ b/tests/test_farm_factory.py
@@ -352,7 +352,7 @@ class TestUpdatePrivilege:
             True,
             {'from': deployer}
         )
-        assert farm_deployer.isPrivilegedDeployer(accounts[1])
+        assert farm_deployer.isPrivilegedUser(accounts[1])
         self.checkEventData(tx.events['PrivilegeUpdated'], accounts[1], True)
 
     def test_removePrivilege(self, farm_deployer):
@@ -366,7 +366,7 @@ class TestUpdatePrivilege:
             False,
             {'from': deployer}
         )
-        assert not farm_deployer.isPrivilegedDeployer(accounts[1])
+        assert not farm_deployer.isPrivilegedUser(accounts[1])
         self.checkEventData(tx.events['PrivilegeUpdated'], accounts[1], False)
 
     def test_updateSamePrivilege_true(self, farm_deployer):
@@ -416,7 +416,7 @@ class TestUpdatePrivilege:
                     True,
                     {'from': deployer}
                 )
-                assert farm_deployer.isPrivilegedDeployer(accounts[i])
+                assert farm_deployer.isPrivilegedUser(accounts[i])
 
 
 # @pytest.mark.skip()


### PR DESCRIPTION
- Privileged deployers and registered farm deployers are separate. Privileged deployers receive a discount on farm creation fees, whereas registered farm deployers are authorized addresses for farm creation.
To avoid this confusion in the future, we will rename isPrivilegedDeployer to isPrivilegedUser for clarity.

<img width="1179" alt="Screenshot 2024-06-18 at 3 37 35 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/7305b1ad-965a-4c26-abdf-b61bdfd2d2ab">
