### PR TITLE
Audit Fixes: QS-3

### DIFF
--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -83,7 +83,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     error InvalidAddress();
     error ZeroAmount();
     error InvalidCooldownPeriod();
-    error CannotWithdraw();
+    error WithdrawTooSoon();
 
     // Disallow initialization of a implementation contract.
     constructor() Ownable(msg.sender) {
@@ -780,7 +780,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @dev Reverts when deposit made in the same transaction.
     function _validateNotRecentDeposit(uint256 _depositTs) internal view {
         if (_depositTs == block.timestamp) {
-            revert CannotWithdraw();
+            revert WithdrawTooSoon();
         }
     }
 

--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -495,7 +495,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
         // Note: If farm is paused, skip the cooldown check.
         if (isFarmActive()) {
             Deposit storage userDeposit = deposits[_depositId];
-            _validateNotRecentDeposit(deposits[_depositId].depositTs);
+            _validateNotRecentDeposit(userDeposit.depositTs);
             if (userDeposit.cooldownPeriod != 0) {
                 revert PleaseInitiateCooldown();
             }

--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -83,6 +83,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     error InvalidAddress();
     error ZeroAmount();
     error InvalidCooldownPeriod();
+    error CannotWithdraw();
 
     // Disallow initialization of a implementation contract.
     constructor() Ownable(msg.sender) {
@@ -435,10 +436,11 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
         // Prepare data to be stored.
         Deposit memory userDeposit = Deposit({
             depositor: _account,
-            cooldownPeriod: 0,
+            liquidity: _liquidity,
             expiryDate: 0,
-            totalRewardsClaimed: new uint256[](rewardTokens.length),
-            liquidity: _liquidity
+            cooldownPeriod: 0,
+            depositTs: block.timestamp,
+            totalRewardsClaimed: new uint256[](rewardTokens.length)
         });
 
         // @dev Pre increment because we want deposit IDs to start with 1.
@@ -493,6 +495,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
         // Note: If farm is paused, skip the cooldown check.
         if (isFarmActive()) {
             Deposit storage userDeposit = deposits[_depositId];
+            _validateNotRecentDeposit(deposits[_depositId].depositTs);
             if (userDeposit.cooldownPeriod != 0) {
                 revert PleaseInitiateCooldown();
             }
@@ -769,6 +772,15 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     function _validateDeposit(address _account, uint256 _depositId) internal view {
         if (deposits[_depositId].depositor != _account || _account == address(0)) {
             revert DepositDoesNotExist();
+        }
+    }
+
+    /// @notice A function to validate deposit ts to prevent flash loan vulnerabilities
+    /// @param _depositTs depositTs of user's deposit. (It represents deposit ts or increaseDeposit ts)
+    /// @dev Reverts when deposit made in the same transaction.
+    function _validateNotRecentDeposit(uint256 _depositTs) internal view {
+        if (_depositTs == block.timestamp) {
+            revert CannotWithdraw();
         }
     }
 

--- a/contracts/features/OperableDeposit.sol
+++ b/contracts/features/OperableDeposit.sol
@@ -103,6 +103,9 @@ abstract contract OperableDeposit is ExpirableFarm {
         _updateSubscriptionForIncrease(_depositId, _amount);
         userDeposit.liquidity += _amount;
 
+        // Update depositTs to prevent flash loan vulnerabilities
+        userDeposit.depositTs = block.timestamp;
+
         emit DepositIncreased(_depositId, _amount);
     }
 
@@ -112,6 +115,7 @@ abstract contract OperableDeposit is ExpirableFarm {
         //Validations.
         _validateFarmOpen(); // Withdraw instead of decrease deposit when farm is closed.
         _validateDeposit(msg.sender, _depositId);
+        _validateNotRecentDeposit(userDeposit.depositTs);
 
         if (_amount == 0) {
             revert CannotWithdrawZeroAmount();

--- a/contracts/interfaces/DataTypes.sol
+++ b/contracts/interfaces/DataTypes.sol
@@ -35,12 +35,14 @@ struct Subscription {
 // liquidity - amount of liquidity in the deposit.
 // expiryDate - expiry time (if deposit is locked).
 // cooldownPeriod - cooldown period in days (if deposit is locked).
+// depositTs - Timestamp of deposit, increaseDeposit saved to prevent deposit and withdrawals in same tx.
 // totalRewardsClaimed - total rewards claimed for the deposit.
 struct Deposit {
     address depositor;
     uint256 liquidity;
     uint256 expiryDate;
     uint256 cooldownPeriod;
+    uint256 depositTs;
     uint256[] totalRewardsClaimed;
 }
 

--- a/test/Farm.t.sol
+++ b/test/Farm.t.sol
@@ -331,7 +331,7 @@ abstract contract WithdrawTest is FarmTest {
         useKnownActor(user)
     {
         uint256 depositId = 1;
-        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        vm.expectRevert(abi.encodeWithSelector(Farm.WithdrawTooSoon.selector));
         Farm(lockupFarm).withdraw(depositId);
     }
 

--- a/test/Farm.t.sol
+++ b/test/Farm.t.sol
@@ -265,6 +265,7 @@ abstract contract WithdrawTest is FarmTest {
         assertEq(depositInfo.liquidity, 0);
         assertEq(depositInfo.expiryDate, 0);
         assertEq(depositInfo.cooldownPeriod, 0);
+        assertEq(depositInfo.depositTs, 0);
     }
 
     function _assertHelperTwo(
@@ -284,6 +285,7 @@ abstract contract WithdrawTest is FarmTest {
                 assertEq(depositInfo.liquidity, 0);
                 assertEq(depositInfo.expiryDate, 0);
                 assertEq(depositInfo.cooldownPeriod, 0);
+                assertEq(depositInfo.depositTs, 0);
 
                 vm.expectRevert(abi.encodeWithSelector(Farm.SubscriptionDoesNotExist.selector));
                 Farm(farm).getSubscriptionInfo(i, 0);
@@ -317,7 +319,19 @@ abstract contract WithdrawTest is FarmTest {
         useKnownActor(user)
     {
         uint256 depositId = 1;
+        skip(1);
         vm.expectRevert(abi.encodeWithSelector(Farm.PleaseInitiateCooldown.selector));
+        Farm(lockupFarm).withdraw(depositId);
+    }
+
+    function test_Withdraw_RevertWhen_DepositInSameTs()
+        public
+        setup
+        depositSetup(lockupFarm, true)
+        useKnownActor(user)
+    {
+        uint256 depositId = 1;
+        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
         Farm(lockupFarm).withdraw(depositId);
     }
 
@@ -405,6 +419,8 @@ abstract contract WithdrawTest is FarmTest {
             if (lockup) {
                 Farm(farm).initiateCooldown(depositId);
                 skip(cooldownTime); //100 seconds after the end of CoolDown Period
+            } else {
+                skip(1);
             }
             Farm(farm).getRewardBalance(rwdTokens[0]);
             Farm(farm).getDepositInfo(depositId);
@@ -452,6 +468,8 @@ abstract contract WithdrawTest is FarmTest {
             if (lockup) {
                 Farm(farm).initiateCooldown(withdrawnDepositId);
                 skip(cooldownTime); //100 seconds after the end of CoolDown Period
+            } else {
+                skip(1);
             }
             Farm(farm).getRewardBalance(rwdTokens[0]);
             Farm(farm).getDepositInfo(withdrawnDepositId);
@@ -502,6 +520,8 @@ abstract contract WithdrawTest is FarmTest {
             if (lockup) {
                 Farm(farm).initiateCooldown(withdrawnDepositId);
                 skip(cooldownTime); //100 seconds after the end of CoolDown Period
+            } else {
+                skip(1);
             }
             Farm(farm).getRewardBalance(rwdTokens[0]);
             Farm(farm).getDepositInfo(withdrawnDepositId);
@@ -552,6 +572,8 @@ abstract contract WithdrawTest is FarmTest {
             if (lockup) {
                 Farm(farm).initiateCooldown(withdrawnDepositId);
                 skip(cooldownTime); //100 seconds after the end of CoolDown Period
+            } else {
+                skip(1);
             }
             Farm(farm).getRewardBalance(rwdTokens[0]);
             Farm(farm).getDepositInfo(withdrawnDepositId);

--- a/test/e20-farms/E20Farm.t.sol
+++ b/test/e20-farms/E20Farm.t.sol
@@ -64,15 +64,6 @@ abstract contract E20FarmWithdrawTest is E20FarmTest {
         vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
         E20Farm(lockupFarm).withdraw(DEPOSIT_ID);
     }
-
-    function test_withdraw_withdrawInSameTransactionAsDeposit()
-        public
-        depositSetup(lockupFarm, true)
-        useKnownActor(user)
-    {
-        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
-        E20Farm(lockupFarm).withdraw(DEPOSIT_ID);
-    }
 }
 
 abstract contract IncreaseDepositTest is E20FarmTest {

--- a/test/e20-farms/E20Farm.t.sol
+++ b/test/e20-farms/E20Farm.t.sol
@@ -61,7 +61,7 @@ abstract contract E20FarmWithdrawTest is E20FarmTest {
         deal(poolAddress, user, amt);
         ERC20(poolAddress).approve(address(lockupFarm), amt);
         E20Farm(lockupFarm).increaseDeposit(DEPOSIT_ID, amt);
-        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        vm.expectRevert(abi.encodeWithSelector(Farm.WithdrawTooSoon.selector));
         E20Farm(lockupFarm).withdraw(DEPOSIT_ID);
     }
 }
@@ -205,7 +205,7 @@ abstract contract DecreaseDepositTest is E20FarmTest {
         deal(poolAddress, user, amt);
         ERC20(poolAddress).approve(address(lockupFarm), amt);
         E20Farm(lockupFarm).increaseDeposit(DEPOSIT_ID, amt);
-        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        vm.expectRevert(abi.encodeWithSelector(Farm.WithdrawTooSoon.selector));
         E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, amt);
     }
 
@@ -214,7 +214,7 @@ abstract contract DecreaseDepositTest is E20FarmTest {
         depositSetup(lockupFarm, true)
         useKnownActor(user)
     {
-        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        vm.expectRevert(abi.encodeWithSelector(Farm.WithdrawTooSoon.selector));
         E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, AMOUNT);
     }
 

--- a/test/e20-farms/E20Farm.t.sol
+++ b/test/e20-farms/E20Farm.t.sol
@@ -49,6 +49,32 @@ abstract contract E20FarmDepositTest is E20FarmTest {
     }
 }
 
+abstract contract E20FarmWithdrawTest is E20FarmTest {
+    function test_revertWhen_withdraw_withdrawInSameTransactionAsIncrease()
+        public
+        depositSetup(lockupFarm, true)
+        useKnownActor(user)
+    {
+        address poolAddress = getPoolAddress();
+        uint256 amt = 500 * 10 ** ERC20(poolAddress).decimals();
+
+        deal(poolAddress, user, amt);
+        ERC20(poolAddress).approve(address(lockupFarm), amt);
+        E20Farm(lockupFarm).increaseDeposit(DEPOSIT_ID, amt);
+        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        E20Farm(lockupFarm).withdraw(DEPOSIT_ID);
+    }
+
+    function test_withdraw_withdrawInSameTransactionAsDeposit()
+        public
+        depositSetup(lockupFarm, true)
+        useKnownActor(user)
+    {
+        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        E20Farm(lockupFarm).withdraw(DEPOSIT_ID);
+    }
+}
+
 abstract contract IncreaseDepositTest is E20FarmTest {
     event DepositIncreased(uint256 indexed depositId, uint256 liquidity);
 
@@ -177,8 +203,33 @@ abstract contract RecoverERC20E20FarmTest is E20FarmTest {
 abstract contract DecreaseDepositTest is E20FarmTest {
     event DepositDecreased(uint256 indexed depositId, uint256 liquidity);
 
+    function test_revertWhen_decreaseDeposit_decreaseInSameTransactionAsIncrease()
+        public
+        depositSetup(lockupFarm, true)
+        useKnownActor(user)
+    {
+        address poolAddress = getPoolAddress();
+        uint256 amt = 500 * 10 ** ERC20(poolAddress).decimals();
+
+        deal(poolAddress, user, amt);
+        ERC20(poolAddress).approve(address(lockupFarm), amt);
+        E20Farm(lockupFarm).increaseDeposit(DEPOSIT_ID, amt);
+        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, amt);
+    }
+
+    function test_decreaseDeposit_decreaseInSameTransactionAsDeposit()
+        public
+        depositSetup(lockupFarm, true)
+        useKnownActor(user)
+    {
+        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdraw.selector));
+        E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, AMOUNT);
+    }
+
     function test_zeroAmount() public depositSetup(lockupFarm, true) useKnownActor(user) {
         uint256 amount;
+        skip(1);
         vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdrawZeroAmount.selector));
         E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, amount);
     }
@@ -261,6 +312,7 @@ abstract contract DecreaseDepositTest is E20FarmTest {
 
 abstract contract E20FarmInheritTest is
     E20FarmDepositTest,
+    E20FarmWithdrawTest,
     IncreaseDepositTest,
     RecoverERC20E20FarmTest,
     DecreaseDepositTest

--- a/test/e721-farms/camelotV3/CamelotV3Farm.t.sol
+++ b/test/e721-farms/camelotV3/CamelotV3Farm.t.sol
@@ -695,6 +695,7 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         depositSetup(lockupFarm, true)
         useKnownActor(user)
     {
+        skip(1);
         vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdrawZeroAmount.selector));
         CamelotV3Farm(lockupFarm).decreaseDeposit(depositId, 0, [uint256(0), uint256(0)]);
     }
@@ -704,6 +705,7 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         depositSetup(lockupFarm, true)
         useKnownActor(user)
     {
+        skip(1);
         vm.expectRevert(abi.encodeWithSelector(OperableDeposit.DecreaseDepositNotPermitted.selector));
         CamelotV3Farm(lockupFarm).decreaseDeposit(depositId, dummyLiquidityToWithdraw, [uint256(0), uint256(0)]);
     }
@@ -713,6 +715,7 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         address farm;
         farm = isLockupFarm ? lockupFarm : nonLockupFarm;
         depositSetupFn(farm, false);
+        skip(1);
 
         uint128 oldLiquidity = uint128(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity);
         uint128 liquidityToWithdraw = uint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
@@ -724,8 +727,9 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         uint256[2] memory minAmounts = [uint256(0), uint256(0)];
         uint256 oldCommonTotalLiquidity =
             CamelotV3Farm(farm).getRewardFundInfo(CamelotV3Farm(farm).COMMON_FUND_ID()).totalLiquidity;
-        uint256 oldUserToken0Balance = IERC20(DAI).balanceOf(currentActor);
-        uint256 oldUserToken1Balance = IERC20(USDCe).balanceOf(currentActor);
+        CamelotV3Farm(farm).claimRewards(depositId);
+        IERC20(DAI).transfer(makeAddr("Random"), IERC20(DAI).balanceOf(currentActor));
+        IERC20(USDCe).transfer(makeAddr("Random"), IERC20(USDCe).balanceOf(currentActor));
 
         vm.expectEmit(farm);
         emit DepositDecreased(depositId, liquidityToWithdraw);
@@ -750,8 +754,8 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         }
         assertTrue(found, "DecreaseLiquidity event not found");
         assertEq(loggedLiquidity, liquidityToWithdraw);
-        assertEq(IERC20(DAI).balanceOf(currentActor), oldUserToken0Balance + loggedAmount0);
-        assertEq(IERC20(USDCe).balanceOf(currentActor), oldUserToken1Balance + loggedAmount1);
+        assertEq(IERC20(DAI).balanceOf(currentActor), loggedAmount0);
+        assertEq(IERC20(USDCe).balanceOf(currentActor), loggedAmount1);
         assertEq(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity, oldLiquidity - liquidityToWithdraw);
         assertEq(
             CamelotV3Farm(farm).getRewardFundInfo(CamelotV3Farm(farm).COMMON_FUND_ID()).totalLiquidity,
@@ -772,6 +776,7 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         address farm;
         farm = isLockupFarm ? lockupFarm : nonLockupFarm;
         depositSetupFn(farm, false);
+        skip(1);
 
         uint128 oldLiquidity = uint128(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity);
         uint128 liquidityToWithdraw = uint128(bound(_liquidityToWithdraw, 1, oldLiquidity));
@@ -783,8 +788,9 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         uint256[2] memory minAmounts = [uint256(0), uint256(0)];
         uint256 oldCommonTotalLiquidity =
             CamelotV3Farm(farm).getRewardFundInfo(CamelotV3Farm(farm).COMMON_FUND_ID()).totalLiquidity;
-        uint256 oldUserToken0Balance = IERC20(DAI).balanceOf(currentActor);
-        uint256 oldUserToken1Balance = IERC20(USDCe).balanceOf(currentActor);
+        CamelotV3Farm(farm).claimRewards(depositId);
+        IERC20(DAI).transfer(makeAddr("Random"), IERC20(DAI).balanceOf(currentActor));
+        IERC20(USDCe).transfer(makeAddr("Random"), IERC20(USDCe).balanceOf(currentActor));
         vm.stopPrank();
 
         address camelotFactoryOwner = ICamelotV3FactoryTesting(CAMELOT_V3_FACTORY).owner();
@@ -807,19 +813,19 @@ abstract contract DecreaseDepositTest is CamelotV3FarmTest {
         uint128 loggedLiquidity;
         uint256 loggedAmount0;
         uint256 loggedAmount1;
-        // bool found = false;
+        bool found = false;
 
         for (uint256 i = 0; i < entries.length; i++) {
             if (entries[i].topics[0] == keccak256("DecreaseLiquidity(uint256,uint128,uint256,uint256)")) {
                 (loggedLiquidity, loggedAmount0, loggedAmount1) =
                     abi.decode(entries[i].data, (uint128, uint256, uint256));
-                // found = true;
+                found = true;
             }
         }
-        // assertTrue(found, "DecreaseLiquidity event not found");
+        assertTrue(found, "DecreaseLiquidity event not found");
         assertEq(loggedLiquidity, liquidityToWithdraw);
-        assertEq(IERC20(DAI).balanceOf(currentActor), oldUserToken0Balance + loggedAmount0);
-        assertEq(IERC20(USDCe).balanceOf(currentActor), oldUserToken1Balance + loggedAmount1);
+        assertEq(IERC20(DAI).balanceOf(currentActor), loggedAmount0);
+        assertEq(IERC20(USDCe).balanceOf(currentActor), loggedAmount1);
         assertEq(CamelotV3Farm(farm).getDepositInfo(depositId).liquidity, oldLiquidity - liquidityToWithdraw);
         assertEq(
             CamelotV3Farm(farm).getRewardFundInfo(CamelotV3Farm(farm).COMMON_FUND_ID()).totalLiquidity,


### PR DESCRIPTION
If someone takes a flash loan, deposits, calibrates rewards and withdraws in the same transaction, the rewards will be inflated till someone calibrates the rewards again. To solve this, we introduced depositTs member inside of Deposit struct to keep track of the time of deposit and increaseDeposit which is checked at the time of withdrawal and decreaseDeposit.

![Screenshot 2024-06-18 at 22 07 45](https://github.com/Sperax/Demeter-Protocol/assets/140178288/7b9c6273-8f91-48e5-b48b-73c5828982a6)
