### PR TITLE
Audit Fixes: QS-5

### DIFF
--- a/contracts/interfaces/IFarm.sol
+++ b/contracts/interfaces/IFarm.sol
@@ -19,4 +19,6 @@ interface IFarm {
     function getRewardFundInfo(uint8 _fundId) external view returns (RewardFund memory);
 
     function getTokenAmounts() external view returns (address[] memory, uint256[] memory);
+
+    function getRewardBalance(address _rwdToken) external view returns (uint256);
 }

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -171,7 +171,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     /// @param _farm Address of the farm for which the end time is to be calculated.
     /// @return rewardsEndingOn Timestamp in seconds till which the rewards are there in farm and in rewarder.
     function rewardsEndTime(address _farm) external view returns (uint256 rewardsEndingOn) {
-        uint256 farmBalance = IERC20(REWARD_TOKEN).balanceOf(_farm);
+        uint256 farmBalance = IFarm(_farm).getRewardBalance(REWARD_TOKEN);
         uint256 rewarderBalance = IERC20(REWARD_TOKEN).balanceOf(address(this));
         rewardsEndingOn = block.timestamp
             + ((farmBalance / farmRewardConfigs[_farm].rewardRate) + (rewarderBalance / totalRewardRate));
@@ -290,7 +290,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
                 rewardRate = farmRewardConfig.maxRewardRate;
             }
             // Calculating the deficit rewards in farm and sending them.
-            uint256 _farmRwdBalance = IERC20(REWARD_TOKEN).balanceOf(_farm);
+            uint256 _farmRwdBalance = IFarm(_farm).getRewardBalance(REWARD_TOKEN);
             uint256 _rewarderRwdBalance = IERC20(REWARD_TOKEN).balanceOf(address(this));
             rewardsToSend = rewardRate * REWARD_PERIOD;
             if (rewardsToSend > _farmRwdBalance) {


### PR DESCRIPTION
While calculating rewards to send in `calibrateRewards` and to view the rewards end time in function `rewardsEndTime` it used to consider farm's reward token balance and it used to avoid accumulated rewards.

Now we have changed to farm reward balance to be considered as `farm.getRewardBalance(token)` instead of `token.balanceOf(farm)`

![Screenshot 2024-06-19 at 12 26 42](https://github.com/Sperax/Demeter-Protocol/assets/140178288/4aa3d58b-41f0-47d2-8ad1-baa04131eb63)
