### PR TITLE
Audit Fixes QS-13

### DIFF
--- a/contracts/interfaces/IFarm.sol
+++ b/contracts/interfaces/IFarm.sol
@@ -8,6 +8,8 @@ interface IFarm {
 
     function setRewardRate(address _rwdToken, uint256[] memory _newRwdRates) external;
 
+    function recoverRewardFunds(address _rwdToken, uint256 _amount) external;
+
     function rewardData(address _token) external view returns (RewardData memory);
 
     function cooldownPeriod() external view returns (uint256);

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -121,7 +121,16 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     /// @param _farm Farm's address in which the token manager is to be updated.
     /// @param _newManager Address of the new token manager.
     function updateTokenManagerOfFarm(address _farm, address _newManager) external onlyOwner {
+        _validateNonZeroAddr(_farm);
         IFarm(_farm).updateRewardData(REWARD_TOKEN, _newManager);
+    }
+
+    /// @notice Function to recover reward funds from the farm.
+    /// @param _farm Farm's address from which reward funds is to be recovered.
+    /// @param _amount Amount which is to be recovered.
+    function recoverRewardFundsOfFarm(address _farm, uint256 _amount) external onlyOwner {
+        _validateNonZeroAddr(_farm);
+        IFarm(_farm).recoverRewardFunds(REWARD_TOKEN, _amount);
     }
 
     /// @notice Function to update APR.

--- a/test/rewarder/Rewarder.t.sol
+++ b/test/rewarder/Rewarder.t.sol
@@ -8,7 +8,7 @@ import {CamelotV2Farm} from "../../contracts/e721-farms/camelotV2/CamelotV2Farm.
 import {RewarderFactory} from "../../contracts/rewarder/RewarderFactory.sol";
 import {Rewarder, IERC20, ERC20} from "../../contracts/rewarder/Rewarder.sol";
 import {IOracle} from "../../contracts/interfaces/IOracle.sol";
-import {VmSafe} from "forge-std/Vm.sol";
+import {Farm} from "./../../contracts/Farm.sol";
 
 contract RewarderTest is CamelotV2FarmTest {
     RewarderFactory public rewarderFactory;
@@ -54,6 +54,29 @@ contract TestUpdateTokenManagerOfFarm is RewarderTest {
         rewarder.updateTokenManagerOfFarm(lockupFarm, actors[1]);
         (address tokenManager,,) = CamelotV2Farm(lockupFarm).rewardData(rewardToken);
         assertEq(tokenManager, actors[1]);
+    }
+}
+
+contract TestRecoverRewardFundsOfFarm is RewarderTest {
+    uint256 public amount;
+
+    function test_RevertWhen_CallerIsNotTheOwner() public useKnownActor(actors[5]) {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, actors[5]));
+        rewarder.recoverRewardFundsOfFarm(lockupFarm, amount);
+    }
+
+    function test_recoverRewardFundsOfFarm() public {
+        vm.prank(owner);
+        CamelotV2Farm(lockupFarm).updateRewardData(USDCe, address(rewarder));
+        uint256 balanceBefore = IERC20(USDCe).balanceOf(address(rewarder));
+        amount = 100 * 10 ** ERC20(USDCe).decimals();
+        deal(USDCe, lockupFarm, amount);
+        vm.expectEmit(true, true, true, true, lockupFarm);
+        emit Farm.FundsRecovered(address(rewarder), USDCe, amount);
+        vm.prank(rewardManager);
+        rewarder.recoverRewardFundsOfFarm(lockupFarm, amount);
+        uint256 balanceAfter = IERC20(USDCe).balanceOf(address(rewarder));
+        assertEq(balanceAfter - balanceBefore, amount);
     }
 }
 


### PR DESCRIPTION
Added a function in `Rewarder` named `recoverRewardFundsOfFarm` to call `recoverRewardFunds` on the farm from rewarder as token manager.

![Screenshot 2024-06-20 at 00 54 15](https://github.com/Sperax/Demeter-Protocol/assets/140178288/353b206b-91af-4562-9b46-a888bb3e121f)
