### PR TITLE
Audit Fixes QS-17 and rewardRate precision bug

### DIFF
--- a/contracts/interfaces/IFarm.sol
+++ b/contracts/interfaces/IFarm.sol
@@ -8,6 +8,8 @@ interface IFarm {
 
     function setRewardRate(address _rwdToken, uint256[] memory _newRwdRates) external;
 
+    function recoverRewardFunds(address _rwdToken, uint256 _amount) external;
+
     function rewardData(address _token) external view returns (RewardData memory);
 
     function cooldownPeriod() external view returns (uint256);

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -121,7 +121,16 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     /// @param _farm Farm's address in which the token manager is to be updated.
     /// @param _newManager Address of the new token manager.
     function updateTokenManagerOfFarm(address _farm, address _newManager) external onlyOwner {
+        _validateNonZeroAddr(_farm);
         IFarm(_farm).updateRewardData(REWARD_TOKEN, _newManager);
+    }
+
+    /// @notice Function to recover reward funds from the farm.
+    /// @param _farm Farm's address from which reward funds is to be recovered.
+    /// @param _amount Amount which is to be recovered.
+    function recoverRewardFundsOfFarm(address _farm, uint256 _amount) external onlyOwner {
+        _validateNonZeroAddr(_farm);
+        IFarm(_farm).recoverRewardFunds(REWARD_TOKEN, _amount);
     }
 
     /// @notice Function to update APR.

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -285,7 +285,9 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
                 totalValue += (
                     priceData.price
                         * _normalizeAmount(
-                            assets[farmRewardConfig.baseAssetIndexes[i]], amounts[farmRewardConfig.baseAssetIndexes[i]]
+                            assets[farmRewardConfig.baseAssetIndexes[i]],
+                            amounts[farmRewardConfig.baseAssetIndexes[i]],
+                            REWARD_TOKEN_DECIMALS
                         )
                 ) / priceData.precision;
                 unchecked {
@@ -400,18 +402,22 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
         return true;
     }
 
-    /// @notice Function to normalize asset amounts to be of Reward token precision.
+    /// @notice Function to normalize asset amounts to be of precision _desiredPrecision.
     /// @param _token Address of the asset token.
     /// @param _amount Amount of the token.
+    /// @param _desiredPrecision Precision of reward token.
     /// @return Normalized amount of the token in _desiredPrecision.
-    function _normalizeAmount(address _token, uint256 _amount) private view returns (uint256) {
+    function _normalizeAmount(address _token, uint256 _amount, uint8 _desiredPrecision)
+        private
+        view
+        returns (uint256)
+    {
         uint8 decimals = _decimals[_token];
-        uint8 rwdTokenDecimals = REWARD_TOKEN_DECIMALS;
-        if (decimals < rwdTokenDecimals) {
-            return _amount * 10 ** (rwdTokenDecimals - decimals);
+        if (decimals < _desiredPrecision) {
+            return _amount * 10 ** (_desiredPrecision - decimals);
         }
-        if (decimals > rwdTokenDecimals) {
-            return _amount / 10 ** (decimals - rwdTokenDecimals);
+        if (decimals > _desiredPrecision) {
+            return _amount / 10 ** (decimals - _desiredPrecision);
         }
         return _amount;
     }

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -285,9 +285,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
                 totalValue += (
                     priceData.price
                         * _normalizeAmount(
-                            assets[farmRewardConfig.baseAssetIndexes[i]],
-                            amounts[farmRewardConfig.baseAssetIndexes[i]],
-                            REWARD_TOKEN_DECIMALS
+                            assets[farmRewardConfig.baseAssetIndexes[i]], amounts[farmRewardConfig.baseAssetIndexes[i]]
                         )
                 ) / priceData.precision;
                 unchecked {
@@ -402,22 +400,18 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
         return true;
     }
 
-    /// @notice Function to normalize asset amounts to be of precision _desiredPrecision.
+    /// @notice Function to normalize asset amounts to be of precision REWARD_TOKEN_DECIMALS.
     /// @param _token Address of the asset token.
     /// @param _amount Amount of the token.
-    /// @param _desiredPrecision Precision of reward token.
     /// @return Normalized amount of the token in _desiredPrecision.
-    function _normalizeAmount(address _token, uint256 _amount, uint8 _desiredPrecision)
-        private
-        view
-        returns (uint256)
-    {
+    function _normalizeAmount(address _token, uint256 _amount) private view returns (uint256) {
         uint8 decimals = _decimals[_token];
-        if (decimals < _desiredPrecision) {
-            return _amount * 10 ** (_desiredPrecision - decimals);
+        uint8 rwdTokenDecimals = REWARD_TOKEN_DECIMALS;
+        if (decimals < rwdTokenDecimals) {
+            return _amount * 10 ** (rwdTokenDecimals - decimals);
         }
-        if (decimals > _desiredPrecision) {
-            return _amount / 10 ** (decimals - _desiredPrecision);
+        if (decimals > rwdTokenDecimals) {
+            return _amount / 10 ** (decimals - rwdTokenDecimals);
         }
         return _amount;
     }

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -72,10 +72,8 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     uint256 public constant REWARD_PERIOD = 1 weeks;
     uint256 public constant DENOMINATOR = 100;
     uint256 public constant ONE_YEAR = 365 days;
-
-    address public REWARD_TOKEN; // solhint-disable-line var-name-mixedcase.
+    address public REWARD_TOKEN; // solhint-disable-line var-name-mixedcase
     uint8 public REWARD_TOKEN_DECIMALS; // solhint-disable-line var-name-mixedcase
-    
     uint256 public totalRewardRate; // Rewards emitted per second for all the farms from this rewarder.
     address public rewarderFactory;
     // farm -> FarmRewardConfig.

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -285,9 +285,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
                 totalValue += (
                     priceData.price
                         * _normalizeAmount(
-                            assets[farmRewardConfig.baseAssetIndexes[i]],
-                            amounts[farmRewardConfig.baseAssetIndexes[i]],
-                            REWARD_TOKEN_DECIMALS
+                            assets[farmRewardConfig.baseAssetIndexes[i]], amounts[farmRewardConfig.baseAssetIndexes[i]]
                         )
                 ) / priceData.precision;
                 unchecked {
@@ -402,22 +400,18 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
         return true;
     }
 
-    /// @notice Function to normalize asset amounts to be of precision _desiredPrecision.
+    /// @notice Function to normalize asset amounts to be of Reward token precision.
     /// @param _token Address of the asset token.
     /// @param _amount Amount of the token.
-    /// @param _desiredPrecision Precision of reward token.
     /// @return Normalized amount of the token in _desiredPrecision.
-    function _normalizeAmount(address _token, uint256 _amount, uint8 _desiredPrecision)
-        private
-        view
-        returns (uint256)
-    {
+    function _normalizeAmount(address _token, uint256 _amount) private view returns (uint256) {
         uint8 decimals = _decimals[_token];
-        if (decimals < _desiredPrecision) {
-            return _amount * 10 ** (_desiredPrecision - decimals);
+        uint8 rwdTokenDecimals = REWARD_TOKEN_DECIMALS;
+        if (decimals < rwdTokenDecimals) {
+            return _amount * 10 ** (rwdTokenDecimals - decimals);
         }
-        if (decimals > _desiredPrecision) {
-            return _amount / 10 ** (decimals - _desiredPrecision);
+        if (decimals > rwdTokenDecimals) {
+            return _amount / 10 ** (decimals - rwdTokenDecimals);
         }
         return _amount;
     }

--- a/test/rewarder/Rewarder.t.sol
+++ b/test/rewarder/Rewarder.t.sol
@@ -140,9 +140,7 @@ contract TestUpdateAPR is RewarderTest {
     }
 
     function test_UpdateAPR_ForBaseTokenDecimalsMoreThanRwdTokenDecimals() public useKnownActor(rewardManager) {
-        vm.mockCall(USDCe, abi.encodeWithSelector(ERC20.decimals.selector), abi.encode(20));
         rewarder = Rewarder(rewarderFactory.deployRewarder(USDCe));
-        vm.clearMockedCalls();
         Rewarder.FarmRewardConfigInput memory rewardConfig;
         address[] memory baseAssets = new address[](1);
         baseAssets[0] = DAI;
@@ -158,7 +156,8 @@ contract TestUpdateAPR is RewarderTest {
         deposit(lockupFarm, false, 1000);
         rewarder.calibrateReward(lockupFarm);
         (, uint256 rewardRate,,) = rewarder.farmRewardConfigs(lockupFarm);
-        assertTrue((rewardRate * 30 days) / 1e20 > 0);
+        assertTrue((rewardRate * 30 days) / 1e6 > 0);
+        assertEq((rewardRate * 30 days) / 1e9, 0);
     }
 
     function test_UpdateAPR_ForRwdTokenDecimalsMoreThanBaseTokenDecimals() public useKnownActor(rewardManager) {
@@ -180,7 +179,7 @@ contract TestUpdateAPR is RewarderTest {
         deposit(lockupFarm, false, 1000);
         rewarder.calibrateReward(lockupFarm);
         (, uint256 rewardRate,,) = rewarder.farmRewardConfigs(lockupFarm);
-        assertTrue((rewardRate * 30 days) / 1e6 > 0);
+        assertTrue((rewardRate * 30 days) / 1e20 > 0);
     }
 
     function _setupFarmRewards() private {

--- a/test/rewarder/Rewarder.t.sol
+++ b/test/rewarder/Rewarder.t.sol
@@ -8,7 +8,7 @@ import {CamelotV2Farm} from "../../contracts/e721-farms/camelotV2/CamelotV2Farm.
 import {RewarderFactory} from "../../contracts/rewarder/RewarderFactory.sol";
 import {Rewarder, IERC20, ERC20} from "../../contracts/rewarder/Rewarder.sol";
 import {IOracle} from "../../contracts/interfaces/IOracle.sol";
-import {VmSafe} from "forge-std/Vm.sol";
+import {Farm} from "./../../contracts/Farm.sol";
 
 contract RewarderTest is CamelotV2FarmTest {
     RewarderFactory public rewarderFactory;
@@ -54,6 +54,29 @@ contract TestUpdateTokenManagerOfFarm is RewarderTest {
         rewarder.updateTokenManagerOfFarm(lockupFarm, actors[1]);
         (address tokenManager,,) = CamelotV2Farm(lockupFarm).rewardData(rewardToken);
         assertEq(tokenManager, actors[1]);
+    }
+}
+
+contract TestRecoverRewardFundsOfFarm is RewarderTest {
+    uint256 public amount;
+
+    function test_RevertWhen_CallerIsNotTheOwner() public useKnownActor(actors[5]) {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, actors[5]));
+        rewarder.recoverRewardFundsOfFarm(lockupFarm, amount);
+    }
+
+    function test_recoverRewardFundsOfFarm() public {
+        vm.prank(owner);
+        CamelotV2Farm(lockupFarm).updateRewardData(USDCe, address(rewarder));
+        uint256 balanceBefore = IERC20(USDCe).balanceOf(address(rewarder));
+        amount = 100 * 10 ** ERC20(USDCe).decimals();
+        deal(USDCe, lockupFarm, amount);
+        vm.expectEmit(true, true, true, true, lockupFarm);
+        emit Farm.FundsRecovered(address(rewarder), USDCe, amount);
+        vm.prank(rewardManager);
+        rewarder.recoverRewardFundsOfFarm(lockupFarm, amount);
+        uint256 balanceAfter = IERC20(USDCe).balanceOf(address(rewarder));
+        assertEq(balanceAfter - balanceBefore, amount);
     }
 }
 

--- a/test/rewarder/Rewarder.t.sol
+++ b/test/rewarder/Rewarder.t.sol
@@ -121,7 +121,7 @@ contract TestUpdateAPR is RewarderTest {
     }
 
     function test_UpdateAPR_CapRewardsWithMaxRwdRate() public useKnownActor(rewardManager) {
-        uint256 MAX_REWARD_RATE = 166665;
+        uint256 MAX_REWARD_RATE = 50; // 50 wei: Because rwdToken decimals are 6
         Rewarder.FarmRewardConfigInput memory rewardConfig;
         address[] memory baseAssets = new address[](1);
         baseAssets[0] = USDCe;
@@ -134,10 +134,54 @@ contract TestUpdateAPR is RewarderTest {
         rewarder.updateRewardConfig(lockupFarm, rewardConfig);
         changePrank(owner);
         CamelotV2Farm(lockupFarm).updateRewardData(USDCe, address(rewarder));
-        deposit(lockupFarm, false, 1000);
+        deposit(lockupFarm, false, 100000);
         rewarder.calibrateReward(lockupFarm);
         (, uint256 rewardRate,,) = rewarder.farmRewardConfigs(lockupFarm);
         assertEq(rewardRate, MAX_REWARD_RATE);
+    }
+
+    function test_UpdateAPR_ForBaseTokenDecimalsMoreThanRwdTokenDecimals() public useKnownActor(rewardManager) {
+        vm.mockCall(USDCe, abi.encodeWithSelector(ERC20.decimals.selector), abi.encode(20));
+        rewarder = Rewarder(rewarderFactory.deployRewarder(USDCe));
+        vm.clearMockedCalls();
+        Rewarder.FarmRewardConfigInput memory rewardConfig;
+        address[] memory baseAssets = new address[](1);
+        baseAssets[0] = DAI;
+        rewardConfig = Rewarder.FarmRewardConfigInput({
+            apr: 12e8,
+            maxRewardRate: UINT256_MAX,
+            baseTokens: baseAssets,
+            nonLockupRewardPer: 5000
+        });
+        rewarder.updateRewardConfig(lockupFarm, rewardConfig);
+        changePrank(owner);
+        CamelotV2Farm(lockupFarm).updateRewardData(USDCe, address(rewarder));
+        deposit(lockupFarm, false, 1000);
+        rewarder.calibrateReward(lockupFarm);
+        (, uint256 rewardRate,,) = rewarder.farmRewardConfigs(lockupFarm);
+        assertTrue((rewardRate * 30 days) / 1e20 > 0);
+    }
+
+    function test_UpdateAPR_ForRwdTokenDecimalsMoreThanBaseTokenDecimals() public useKnownActor(rewardManager) {
+        vm.mockCall(USDCe, abi.encodeWithSelector(ERC20.decimals.selector), abi.encode(20));
+        rewarder = Rewarder(rewarderFactory.deployRewarder(USDCe));
+        vm.clearMockedCalls();
+        Rewarder.FarmRewardConfigInput memory rewardConfig;
+        address[] memory baseAssets = new address[](1);
+        baseAssets[0] = DAI;
+        rewardConfig = Rewarder.FarmRewardConfigInput({
+            apr: 12e8,
+            maxRewardRate: UINT256_MAX,
+            baseTokens: baseAssets,
+            nonLockupRewardPer: 5000
+        });
+        rewarder.updateRewardConfig(lockupFarm, rewardConfig);
+        changePrank(owner);
+        CamelotV2Farm(lockupFarm).updateRewardData(USDCe, address(rewarder));
+        deposit(lockupFarm, false, 1000);
+        rewarder.calibrateReward(lockupFarm);
+        (, uint256 rewardRate,,) = rewarder.farmRewardConfigs(lockupFarm);
+        assertTrue((rewardRate * 30 days) / 1e6 > 0);
     }
 
     function _setupFarmRewards() private {


### PR DESCRIPTION
![Screenshot 2024-06-20 at 19 00 41](https://github.com/Sperax/Demeter-Protocol/assets/140178288/4b36c681-d150-4c9e-a786-eb2c824ab69f)

# NOTE: 
Also we found out that the totalValue is always in 18 precision and that is used to calculate and set rewardRate. Here, if the reward token is not in 18 precision, for example USDCe which has 6 decimals. The rewards would be highly inflated.