### PR TITLE
Audit Fixed QS-12

### DIFF
--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -298,7 +298,6 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
                 if (rewardsToSend > _rewarderRwdBalance) {
                     rewardsToSend = _rewarderRwdBalance;
                 }
-                IERC20(REWARD_TOKEN).safeTransfer(_farm, rewardsToSend);
             } else {
                 rewardsToSend = 0;
             }
@@ -312,6 +311,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
         farmRewardConfigs[_farm].rewardRate = rewardRate;
         emit RewardCalibrated(_farm, rewardsToSend, rewardRate);
         _setRewardRate(_farm, rewardRate, farmRewardConfig.nonLockupRewardPer);
+        if (rewardsToSend != 0) IERC20(REWARD_TOKEN).safeTransfer(_farm, rewardsToSend);
     }
 
     /// @notice Function to set reward rate in the farm.


### PR DESCRIPTION
As per the audit review comment, the farm's reward data was not getting updated because Rewarder sends the tokens to the farm via `safeTransfer` instead of `addRewards`. However when the `Rewarder` calls `farm.setRewardRate`, it updates the farm reward data but the ideal scenarion would be to checkout farm's reward data first and then transfer the tokens.

![Screenshot 2024-06-20 at 20 23 40](https://github.com/Sperax/Demeter-Protocol/assets/140178288/7c95ba1c-7f7c-4d28-89ea-c2737dd5aecf)
