### PR TITLE
Audit fixes: QS-6

### DIFF
--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -118,7 +118,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
         if (rewardData[_rwdToken].tknManager == address(0)) {
             revert InvalidRewardToken();
         }
-        _updateFarmRewardData();
+        updateFarmRewardData();
         IERC20(_rwdToken).safeTransferFrom(msg.sender, address(this), _amount);
         emit RewardAdded(_rwdToken, _amount);
     }
@@ -144,7 +144,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
         if (isPaused == _isPaused) {
             revert FarmAlreadyInRequiredState();
         }
-        _updateFarmRewardData();
+        updateFarmRewardData();
         isPaused = _isPaused;
         emit FarmPaused(isPaused);
     }
@@ -153,7 +153,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @dev Shuts down the farm completely.
     function closeFarm() external onlyOwner nonReentrant {
         _validateFarmOpen();
-        _updateFarmRewardData();
+        updateFarmRewardData();
         isPaused = true;
         isClosed = true;
         uint256 numRewards = rewardTokens.length;
@@ -180,7 +180,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @dev Function recovers minOf(_amount, rewardsLeft).
     function recoverRewardFunds(address _rwdToken, uint256 _amount) external nonReentrant {
         _validateTokenManager(_rwdToken);
-        _updateFarmRewardData();
+        updateFarmRewardData();
         _recoverRewardFunds(_rwdToken, _amount);
     }
 
@@ -190,7 +190,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     function setRewardRate(address _rwdToken, uint256[] memory _newRewardRates) external {
         _validateFarmOpen();
         _validateTokenManager(_rwdToken);
-        _updateFarmRewardData();
+        updateFarmRewardData();
         _setRewardRate(_rwdToken, _newRewardRates);
     }
 
@@ -319,6 +319,38 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @dev This function should be overridden to add the respective logic.
     function getTokenAmounts() external view virtual returns (address[] memory, uint256[] memory);
 
+    /// @notice Function to update the FarmRewardData for all funds.
+    function updateFarmRewardData() public virtual {
+        uint256 time = _getRewardAccrualTimeElapsed();
+        if (time > 0) {
+            // Accrue rewards if farm is active.
+            if (isFarmActive()) {
+                uint256 numFunds = rewardFunds.length;
+                uint256 numRewards = rewardTokens.length;
+                // Update the reward funds.
+                for (uint8 iFund; iFund < numFunds;) {
+                    RewardFund storage fund = rewardFunds[iFund];
+                    if (fund.totalLiquidity != 0) {
+                        for (uint8 iRwd; iRwd < numRewards;) {
+                            // Get the accrued rewards for the time.
+                            uint256 accRewards = _getAccRewards(iRwd, iFund, time);
+                            rewardData[rewardTokens[iRwd]].accRewardBal += accRewards;
+                            fund.accRewardPerShare[iRwd] += (accRewards * PREC) / fund.totalLiquidity;
+
+                            unchecked {
+                                ++iRwd;
+                            }
+                        }
+                    }
+                    unchecked {
+                        ++iFund;
+                    }
+                }
+            }
+        }
+        _updateLastRewardAccrualTime(); // Update the last reward accrual time.
+    }
+
     /// @notice Claim rewards for the user.
     /// @param _account The user's address.
     /// @param _depositId The id of the deposit.
@@ -427,7 +459,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
             revert NoLiquidityInPosition();
         }
         // Update the reward funds.
-        _updateFarmRewardData();
+        updateFarmRewardData();
 
         // Prepare data to be stored.
         Deposit memory userDeposit = Deposit({
@@ -526,7 +558,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @dev NOTE: any function calling this private
     ///     function should be marked as non-reentrant.
     function _updateAndClaimFarmRewards(uint256 _depositId) internal {
-        _updateFarmRewardData();
+        updateFarmRewardData();
 
         Deposit storage userDeposit = deposits[_depositId];
         Subscription[] storage depositSubs = subscriptions[_depositId];
@@ -616,38 +648,6 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
             }
         }
         emit RewardRateUpdated(_rwdToken, _newRewardRates);
-    }
-
-    /// @notice Function to update the FarmRewardData for all funds.
-    function _updateFarmRewardData() internal virtual {
-        uint256 time = _getRewardAccrualTimeElapsed();
-        if (time > 0) {
-            // Accrue rewards if farm is active.
-            if (isFarmActive()) {
-                uint256 numFunds = rewardFunds.length;
-                uint256 numRewards = rewardTokens.length;
-                // Update the reward funds.
-                for (uint8 iFund; iFund < numFunds;) {
-                    RewardFund storage fund = rewardFunds[iFund];
-                    if (fund.totalLiquidity != 0) {
-                        for (uint8 iRwd; iRwd < numRewards;) {
-                            // Get the accrued rewards for the time.
-                            uint256 accRewards = _getAccRewards(iRwd, iFund, time);
-                            rewardData[rewardTokens[iRwd]].accRewardBal += accRewards;
-                            fund.accRewardPerShare[iRwd] += (accRewards * PREC) / fund.totalLiquidity;
-
-                            unchecked {
-                                ++iRwd;
-                            }
-                        }
-                    }
-                    unchecked {
-                        ++iFund;
-                    }
-                }
-            }
-        }
-        _updateLastRewardAccrualTime(); // Update the last reward accrual time.
     }
 
     /// @notice Function to setup the reward funds and initialize the farm global params during construction.

--- a/test/Farm.t.sol
+++ b/test/Farm.t.sol
@@ -1179,7 +1179,7 @@ abstract contract MulticallTest is FarmTest {
 
     function test_Multicall_RevertWhen_CallInternalFunction() public useKnownActor(owner) {
         bytes[] memory data = new bytes[](1);
-        data[0] = abi.encodeWithSignature("_updateFarmRewardData()");
+        data[0] = abi.encodeWithSignature("_updateLastRewardAccrualTime()");
 
         vm.expectRevert(Address.FailedInnerCall.selector);
         Farm(lockupFarm).multicall(data);


### PR DESCRIPTION
We made _updateFarmRewardData public and renamed it to updateFarmRewardData. This function can now be triggered externally before farmEndTime to accrue user rewards, which otherwise cannot be accrued after the farm expires.

We attempted to modify _updateFarmRewardData to accrue rewards until farmEndTime even if the farm has expired. However, this approach became too complicated with multiple edge cases. To keep the code simple, we chose to make this function public and resolve the problem using off-chain measures.

<img width="1085" alt="Screenshot 2024-06-21 at 3 27 31 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/0ec978d8-5a54-4f8f-b8a3-a23e709d8723">
