### PR TITLE
Audit Fixes QS-11

### DIFF
--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -47,7 +47,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     event PoolSubscribed(uint256 indexed depositId, uint8 fundId);
     event FarmStartTimeUpdated(uint256 newStartTime);
     event CooldownPeriodUpdated(uint256 newCooldownPeriod);
-    event RewardRateUpdated(address indexed rwdToken, uint256[] newRewardRate);
+    event RewardRateUpdated(address indexed rwdToken, uint128[] newRewardRate);
     event RewardAdded(address rwdToken, uint256 amount);
     event FarmClosed();
     event RecoveredERC20(address token, uint256 amount);
@@ -158,7 +158,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
         uint256 numRewards = rewardTokens.length;
         for (uint8 iRwd; iRwd < numRewards;) {
             _recoverRewardFunds(rewardTokens[iRwd], type(uint256).max);
-            _setRewardRate(rewardTokens[iRwd], new uint256[](rewardFunds.length));
+            _setRewardRate(rewardTokens[iRwd], new uint128[](rewardFunds.length));
             unchecked {
                 ++iRwd;
             }
@@ -186,7 +186,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @notice Function to update reward params for a fund.
     /// @param _rwdToken The reward token's address.
     /// @param _newRewardRates The new reward rate for the fund (includes the precision).
-    function setRewardRate(address _rwdToken, uint256[] memory _newRewardRates) external {
+    function setRewardRate(address _rwdToken, uint128[] memory _newRewardRates) external {
         _validateFarmOpen();
         _validateTokenManager(_rwdToken);
         updateFarmRewardData();
@@ -634,7 +634,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @notice Function to update reward params for a fund.
     /// @param _rwdToken The reward token's address.
     /// @param _newRewardRates The new reward rate for the fund (includes the precision).
-    function _setRewardRate(address _rwdToken, uint256[] memory _newRewardRates) internal {
+    function _setRewardRate(address _rwdToken, uint128[] memory _newRewardRates) internal {
         uint8 id = rewardData[_rwdToken].id;
         uint256 numFunds = rewardFunds.length;
         if (_newRewardRates.length != numFunds) {

--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -115,9 +115,8 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
             revert ZeroAmount();
         }
         _validateFarmOpen();
-        if (rewardData[_rwdToken].tknManager == address(0)) {
-            revert InvalidRewardToken();
-        }
+        _validateRewardToken(_rwdToken);
+
         updateFarmRewardData();
         IERC20(_rwdToken).safeTransferFrom(msg.sender, address(this), _amount);
         emit RewardAdded(_rwdToken, _amount);
@@ -286,6 +285,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     /// @param _rwdToken The reward token's address.
     /// @return The reward rates for the reward token (uint256[]).
     function getRewardRates(address _rwdToken) external view returns (uint256[] memory) {
+        _validateRewardToken(_rwdToken);
         uint256 numFunds = rewardFunds.length;
         uint256[] memory rates = new uint256[](numFunds);
         uint8 id = rewardData[_rwdToken].id;
@@ -402,9 +402,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     function getRewardBalance(address _rwdToken) public view returns (uint256) {
         RewardData memory rwdData = rewardData[_rwdToken];
 
-        if (rwdData.tknManager == address(0)) {
-            revert InvalidRewardToken();
-        }
+        _validateRewardToken(_rwdToken);
 
         uint256 numFunds = rewardFunds.length;
         uint256 rewardsAcc = rwdData.accRewardBal;
@@ -802,6 +800,14 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
     function _validateTokenManager(address _rwdToken) internal view {
         if (msg.sender != rewardData[_rwdToken].tknManager) {
             revert NotTheTokenManager();
+        }
+    }
+
+    /// @notice Validate the reward token is valid.
+    /// @param _rwdToken Address of reward token.
+    function _validateRewardToken(address _rwdToken) internal view {
+        if (rewardData[_rwdToken].tknManager == address(0)) {
+            revert InvalidRewardToken();
         }
     }
 

--- a/contracts/FarmDeployer.sol
+++ b/contracts/FarmDeployer.sol
@@ -49,6 +49,7 @@ abstract contract FarmDeployer is Ownable, ReentrancyGuard {
 
     // Custom Errors
     error InvalidAddress();
+    error NewFarmImplementationSameAsOld();
 
     /// @notice Constructor.
     /// @param _farmRegistry Address of the Demeter Farm Registry.
@@ -62,7 +63,14 @@ abstract contract FarmDeployer is Ownable, ReentrancyGuard {
     /// @notice Update farm implementation's address.
     /// @dev Only callable by the owner.
     /// @param _newFarmImplementation New farm implementation's address.
+    /// @dev Ensure that `_newFarmId` is correct for the new farm implementation.
     function updateFarmImplementation(address _newFarmImplementation, string calldata _newFarmId) external onlyOwner {
+        _validateNonZeroAddr(_newFarmImplementation);
+
+        if (farmImplementation == _newFarmImplementation) {
+            revert NewFarmImplementationSameAsOld();
+        }
+
         farmId = _newFarmId;
         farmImplementation = _newFarmImplementation;
 

--- a/contracts/FarmRegistry.sol
+++ b/contracts/FarmRegistry.sol
@@ -78,6 +78,7 @@ contract FarmRegistry is OwnableUpgradeable {
     /// @param _farm Address of the created farm contract
     /// @param _creator Address of the farm creator.
     function registerFarm(address _farm, address _creator) external {
+        _validateNonZeroAddr(_farm);
         if (!deployerRegistered[msg.sender]) {
             revert DeployerNotRegistered();
         }

--- a/contracts/FarmRegistry.sol
+++ b/contracts/FarmRegistry.sol
@@ -49,6 +49,7 @@ contract FarmRegistry is OwnableUpgradeable {
 
     // Custom Errors.
     error DeployerNotRegistered();
+    error FarmAlreadyRegistered();
     error DeployerAlreadyRegistered();
     error InvalidDeployerId();
     error PrivilegeSameAsDesired();
@@ -80,6 +81,10 @@ contract FarmRegistry is OwnableUpgradeable {
         if (!deployerRegistered[msg.sender]) {
             revert DeployerNotRegistered();
         }
+        if (farmRegistered[_farm]) {
+            revert FarmAlreadyRegistered();
+        }
+
         farms.push(_farm);
         farmRegistered[_farm] = true;
         emit FarmRegistered(_farm, _creator, msg.sender);

--- a/contracts/features/OperableDeposit.sol
+++ b/contracts/features/OperableDeposit.sol
@@ -39,6 +39,7 @@ abstract contract OperableDeposit is ExpirableFarm {
 
     // Custom Errors.
     error DecreaseDepositNotPermitted();
+    error InsufficientLiquidity();
 
     /// @notice Update subscription data of a deposit for increase in liquidity.
     /// @param _depositId Unique deposit id for the deposit.
@@ -119,6 +120,9 @@ abstract contract OperableDeposit is ExpirableFarm {
 
         if (_amount == 0) {
             revert CannotWithdrawZeroAmount();
+        }
+        if (_amount > userDeposit.liquidity) {
+            revert InsufficientLiquidity();
         }
 
         if (userDeposit.expiryDate != 0 || userDeposit.cooldownPeriod != 0) {

--- a/contracts/interfaces/IFarm.sol
+++ b/contracts/interfaces/IFarm.sol
@@ -6,7 +6,7 @@ import {RewardData, RewardFund} from "./DataTypes.sol";
 interface IFarm {
     function updateRewardData(address _rwdToken, address _newTknManager) external;
 
-    function setRewardRate(address _rwdToken, uint256[] memory _newRwdRates) external;
+    function setRewardRate(address _rwdToken, uint128[] memory _newRewardRates) external;
 
     function recoverRewardFunds(address _rwdToken, uint256 _amount) external;
 

--- a/contracts/rewarder/Rewarder.sol
+++ b/contracts/rewarder/Rewarder.sol
@@ -32,6 +32,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IOracle} from "../interfaces/IOracle.sol";
 import {IFarm} from "../interfaces/IFarm.sol";
 import {IRewarderFactory} from "../interfaces/IRewarderFactory.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /// @title Rewarder contract of Demeter Protocol.
 /// @author Sperax Foundation.
@@ -49,8 +50,8 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     // nonLockupRewardPer - Reward percentage allocation for no lockup fund (rest goes to lockup fund).
     struct FarmRewardConfig {
         uint256 apr;
-        uint256 rewardRate;
-        uint256 maxRewardRate;
+        uint128 rewardRate;
+        uint128 maxRewardRate;
         uint256[] baseAssetIndexes;
         uint256 nonLockupRewardPer; // 5e3 = 50%.
     }
@@ -62,7 +63,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     // nonLockupRewardPer - Reward percentage allocation for no lockup fund (rest goes to lockup fund).
     struct FarmRewardConfigInput {
         uint256 apr;
-        uint256 maxRewardRate;
+        uint128 maxRewardRate;
         address[] baseTokens;
         uint256 nonLockupRewardPer; // 5e3 = 50%.
     }
@@ -272,7 +273,7 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
 
     function _calibrateReward(address _farm) private returns (uint256 rewardsToSend) {
         FarmRewardConfig memory farmRewardConfig = farmRewardConfigs[_farm];
-        uint256 rewardRate;
+        uint128 rewardRate;
         if (farmRewardConfig.apr != 0) {
             (address[] memory assets, uint256[] memory amounts) = _getTokenAmounts(_farm);
             // Calculating total USD value for all the assets.
@@ -298,9 +299,10 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
             // For token with lower decimals the calculation of rewardRate might not be accurate because of precision loss in truncation.
             // rewardValuePerSecond = (APR * totalValue / 100) / 365 days.
             // rewardRate = rewardValuePerSecond * pricePrecision / price.
-            rewardRate = (farmRewardConfig.apr * totalValue * priceData.precision)
-                / (APR_PRECISION * DENOMINATOR * ONE_YEAR * priceData.price);
-
+            rewardRate = SafeCast.toUint128(
+                (farmRewardConfig.apr * totalValue * priceData.precision)
+                    / (APR_PRECISION * DENOMINATOR * ONE_YEAR * priceData.price)
+            );
             if (rewardRate > farmRewardConfig.maxRewardRate) {
                 rewardRate = farmRewardConfig.maxRewardRate;
             }
@@ -333,15 +335,15 @@ contract Rewarder is Ownable, Initializable, ReentrancyGuard {
     /// @param _farm Address of the farm.
     /// @param _rwdRate Reward per second to be emitted.
     /// @param _nonLockupRewardPer Reward percentage to be allocated to no lockup fund.
-    function _setRewardRate(address _farm, uint256 _rwdRate, uint256 _nonLockupRewardPer) private {
-        uint256[] memory _newRewardRates;
+    function _setRewardRate(address _farm, uint128 _rwdRate, uint256 _nonLockupRewardPer) private {
+        uint128[] memory _newRewardRates;
         if (IFarm(_farm).cooldownPeriod() == 0) {
-            _newRewardRates = new uint256[](1);
+            _newRewardRates = new uint128[](1);
             _newRewardRates[0] = _rwdRate;
             IFarm(_farm).setRewardRate(REWARD_TOKEN, _newRewardRates);
         } else {
-            _newRewardRates = new uint256[](2);
-            uint256 commonFundShare = (_rwdRate * _nonLockupRewardPer) / MAX_PERCENTAGE;
+            _newRewardRates = new uint128[](2);
+            uint128 commonFundShare = SafeCast.toUint128((_rwdRate * _nonLockupRewardPer) / MAX_PERCENTAGE);
             _newRewardRates[0] = commonFundShare;
             _newRewardRates[1] = _rwdRate - commonFundShare;
             IFarm(_farm).setRewardRate(REWARD_TOKEN, _newRewardRates);

--- a/test/Farm.t.sol
+++ b/test/Farm.t.sol
@@ -1080,6 +1080,14 @@ abstract contract CloseFarmTest is FarmTest {
     }
 }
 
+// TODO add more positive test cases
+abstract contract GetRewardRates is FarmTest {
+    function test_RevertWhen_InvalidRewardToken() public setup {
+        vm.expectRevert(abi.encodeWithSelector(Farm.InvalidRewardToken.selector));
+        Farm(nonLockupFarm).getRewardRates(invalidRewardToken);
+    }
+}
+
 abstract contract _SetupFarmTest is FarmTest {
     function test_SetupFarm_RevertWhen_InvalidFarmStartTime() public {
         vm.expectRevert(abi.encodeWithSelector(Farm.InvalidFarmStartTime.selector));

--- a/test/Farm.t.sol
+++ b/test/Farm.t.sol
@@ -8,6 +8,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {TestNetworkConfig} from "./utils/TestNetworkConfig.t.sol";
 import {Deposit, Subscription, RewardData, RewardFund} from "../contracts/interfaces/DataTypes.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 abstract contract FarmTest is TestNetworkConfig {
     uint8 public constant COMMON_FUND_ID = 0;
@@ -38,7 +39,7 @@ abstract contract FarmTest is TestNetworkConfig {
     event PoolSubscribed(uint256 indexed depositId, uint8 fundId);
     event FarmStartTimeUpdated(uint256 newStartTime);
     event CooldownPeriodUpdated(uint256 newCooldownPeriod);
-    event RewardRateUpdated(address indexed rwdToken, uint256[] newRewardRate);
+    event RewardRateUpdated(address indexed rwdToken, uint128[] newRewardRate);
     event RewardAdded(address rwdToken, uint256 amount);
     event FarmClosed();
     event RecoveredERC20(address token, uint256 amount);
@@ -94,16 +95,22 @@ abstract contract FarmTest is TestNetworkConfig {
     function _setRewardRates(address _farm, bool _customRwdRate, uint256 _rwdRate) internal {
         address[] memory farmRewardTokens = getRewardTokens(_farm);
         if (Farm(_farm).cooldownPeriod() != 0) {
-            uint256[] memory rwdRate = new uint256[](2);
+            uint128[] memory rwdRate = new uint128[](2);
             for (uint8 i; i < farmRewardTokens.length; ++i) {
-                rwdRate[0] = _customRwdRate ? _rwdRate : 1 * 10 ** ERC20(farmRewardTokens[i]).decimals() / 100; //0.01;
-                rwdRate[1] = _customRwdRate ? _rwdRate : 2 * 10 ** ERC20(farmRewardTokens[i]).decimals() / 100; //0.02;
+                rwdRate[0] = SafeCast.toUint128(
+                    _customRwdRate ? _rwdRate : 1 * 10 ** ERC20(farmRewardTokens[i]).decimals() / 100
+                ); //0.01;
+                rwdRate[1] = SafeCast.toUint128(
+                    _customRwdRate ? _rwdRate : 2 * 10 ** ERC20(farmRewardTokens[i]).decimals() / 100
+                ); //0.02;
                 Farm(_farm).setRewardRate(farmRewardTokens[i], rwdRate);
             }
         } else {
-            uint256[] memory rwdRate = new uint256[](1);
+            uint128[] memory rwdRate = new uint128[](1);
             for (uint8 i; i < farmRewardTokens.length; ++i) {
-                rwdRate[0] = _customRwdRate ? _rwdRate : 1 * 10 ** ERC20(farmRewardTokens[i]).decimals() / 100; //0.01;
+                rwdRate[0] = SafeCast.toUint128(
+                    _customRwdRate ? _rwdRate : 1 * 10 ** ERC20(farmRewardTokens[i]).decimals() / 100
+                ); //0.01;
                 Farm(_farm).setRewardRate(farmRewardTokens[i], rwdRate);
             }
         }
@@ -268,7 +275,7 @@ abstract contract ClaimRewardsTest is FarmTest {
     function test_claimRewards_rwd_rate_0() public setup depositSetup(nonLockupFarm, false) {
         uint256 time = 15 days;
         uint256 depositId = 1;
-        uint256[] memory rwdRate = new uint256[](1);
+        uint128[] memory rwdRate = new uint128[](1);
         address[] memory rewardTokens = getRewardTokens(nonLockupFarm);
         uint256[] memory balances = new uint256[](rewardTokens.length);
         for (uint8 i; i < rewardTokens.length; ++i) {
@@ -744,7 +751,7 @@ abstract contract AddRewardsTest is FarmTest {
 
 abstract contract SetRewardRateTest is FarmTest {
     function test_SetRewardRate_RevertWhen_FarmIsClosed() public useKnownActor(owner) {
-        uint256[] memory rwdRate = new uint256[](1);
+        uint128[] memory rwdRate = new uint128[](1);
         address[] memory rewardTokens = getRewardTokens(nonLockupFarm);
         rwdRate[0] = ERC20(rewardTokens[0]).decimals();
         Farm(nonLockupFarm).closeFarm();
@@ -753,11 +760,11 @@ abstract contract SetRewardRateTest is FarmTest {
     }
 
     function test_SetRewardRate_RevertWhen_InvalidRewardRatesLength() public useKnownActor(owner) {
-        uint256[] memory rwdRate = new uint256[](1);
+        uint128[] memory rwdRate = new uint128[](1);
         address[] memory rewardTokens = getRewardTokens(nonLockupFarm);
         for (uint8 i; i < rewardTokens.length; ++i) {
             uint8 decimals = ERC20(rewardTokens[i]).decimals();
-            rwdRate[0] = 2 * 10 ** decimals;
+            rwdRate[0] = SafeCast.toUint128(2 * 10 ** decimals);
             vm.startPrank(currentActor);
             vm.expectRevert(abi.encodeWithSelector(Farm.InvalidRewardRatesLength.selector));
             Farm(lockupFarm).setRewardRate(rewardTokens[i], rwdRate);
@@ -766,27 +773,30 @@ abstract contract SetRewardRateTest is FarmTest {
 
     function testFuzz_setRewardRate(bool lockup, uint256 rwdRateNonLockup, uint256 rwdRateLockup) public {
         address farm = lockup ? lockupFarm : nonLockupFarm;
-        uint256[] memory rwdRate;
+        uint128[] memory rwdRate;
         if (lockup) {
-            rwdRate = new uint256[](2);
+            rwdRate = new uint128[](2);
         } else {
-            rwdRate = new uint256[](1);
+            rwdRate = new uint128[](1);
         }
         vm.startPrank(owner);
         address[] memory rewardTokens = getRewardTokens(farm);
         for (uint8 i; i < rewardTokens.length; ++i) {
             uint8 decimals = ERC20(rewardTokens[i]).decimals();
             rwdRateNonLockup = bound(rwdRateNonLockup, 1 * 10 ** decimals, 2 * 10 ** decimals);
-            rwdRate[0] = rwdRateNonLockup;
+            rwdRate[0] = SafeCast.toUint128(rwdRateNonLockup);
             if (lockup) {
                 rwdRateLockup = bound(rwdRateLockup, 2 * 10 ** decimals, 4 * 10 ** decimals);
-                rwdRate[1] = rwdRateLockup;
+                rwdRate[1] = SafeCast.toUint128(rwdRateLockup);
             }
 
             vm.expectEmit(address(farm));
             emit RewardRateUpdated(rewardTokens[i], rwdRate);
             Farm(farm).setRewardRate(rewardTokens[i], rwdRate);
-            assertEq(Farm(farm).getRewardRates(rewardTokens[i]), rwdRate);
+            assertEq(Farm(farm).getRewardRates(rewardTokens[i])[0], rwdRate[0]);
+            if (lockup) {
+                assertEq(Farm(farm).getRewardRates(rewardTokens[i])[1], rwdRate[1]);
+            }
         }
     }
 }
@@ -1073,14 +1083,17 @@ abstract contract CloseFarmTest is FarmTest {
             address farm = lockup ? lockupFarm : nonLockupFarm;
             uint256 rewardRateLength = lockup ? 2 : 1;
             address[] memory rewardTokens = getRewardTokens(farm);
-            uint256[] memory rwdRate = new uint256[](rewardRateLength);
+            uint128[] memory rwdRate = new uint128[](rewardRateLength);
             vm.expectEmit(address(farm));
             emit FarmClosed();
             Farm(farm).closeFarm();
             assertEq(Farm(farm).isFarmOpen(), false);
             assertEq(Farm(farm).isFarmActive(), false);
             for (uint256 i = 0; i < rwdTokens.length; i++) {
-                assertEq(Farm(farm).getRewardRates(rewardTokens[i]), rwdRate);
+                assertEq(Farm(farm).getRewardRates(rewardTokens[i])[0], rwdRate[0]);
+                if (lockup) {
+                    assertEq(Farm(farm).getRewardRates(rewardTokens[i])[1], rwdRate[1]);
+                }
             }
 
             // this function also recovers reward funds. Need to test that here.

--- a/test/FarmRegistry.t.sol
+++ b/test/FarmRegistry.t.sol
@@ -100,6 +100,20 @@ contract RegisterFarmTest is FarmRegistryTest {
         FarmRegistry(registry).registerFarm(actors[6], actors[4]);
     }
 
+    function test_RevertWhen_InvalidAddress()
+        public
+        useKnownActor(FARM_REGISTRY_OWNER)
+        initialized
+        deployerRegistered
+    {
+        address farm = actors[6];
+        address creator = actors[5];
+        vm.startPrank(owner);
+
+        vm.expectRevert(abi.encodeWithSelector(FarmRegistry.InvalidAddress.selector));
+        FarmRegistry(registry).registerFarm(address(0), creator);
+    }
+
     function test_RevertWhen_FarmAlreadyRegistered()
         public
         useKnownActor(FARM_REGISTRY_OWNER)

--- a/test/FarmRegistry.t.sol
+++ b/test/FarmRegistry.t.sol
@@ -100,6 +100,21 @@ contract RegisterFarmTest is FarmRegistryTest {
         FarmRegistry(registry).registerFarm(actors[6], actors[4]);
     }
 
+    function test_RevertWhen_FarmAlreadyRegistered()
+        public
+        useKnownActor(FARM_REGISTRY_OWNER)
+        initialized
+        deployerRegistered
+    {
+        address farm = actors[6];
+        address creator = actors[5];
+        vm.startPrank(owner);
+
+        FarmRegistry(registry).registerFarm(farm, creator);
+        vm.expectRevert(abi.encodeWithSelector(FarmRegistry.FarmAlreadyRegistered.selector));
+        FarmRegistry(registry).registerFarm(farm, creator);
+    }
+
     function test_registerFarm() public useKnownActor(FARM_REGISTRY_OWNER) initialized deployerRegistered {
         address farm = actors[6];
         address creator = actors[5];

--- a/test/e20-farms/E20Farm.t.sol
+++ b/test/e20-farms/E20Farm.t.sol
@@ -225,6 +225,19 @@ abstract contract DecreaseDepositTest is E20FarmTest {
         E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, amount);
     }
 
+    function test_CannotWithdrawZeroAmount() public depositSetup(lockupFarm, true) useKnownActor(user) {
+        skip(1 days * 7);
+        vm.expectRevert(abi.encodeWithSelector(Farm.CannotWithdrawZeroAmount.selector));
+        E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, 0);
+    }
+
+    function test_InsufficientLiquidity() public depositSetup(lockupFarm, true) useKnownActor(user) {
+        skip(1 days * 7);
+        Deposit memory depositInfo = E20Farm(lockupFarm).getDepositInfo(DEPOSIT_ID);
+        vm.expectRevert(abi.encodeWithSelector(OperableDeposit.InsufficientLiquidity.selector));
+        E20Farm(lockupFarm).decreaseDeposit(DEPOSIT_ID, depositInfo.liquidity + 1);
+    }
+
     function test_DecreaseDeposit_RevertWhen_LockupFarm_DecreaseDepositNotPermitted()
         public
         depositSetup(lockupFarm, true)

--- a/test/rewarder/Rewarder.t.sol
+++ b/test/rewarder/Rewarder.t.sol
@@ -120,7 +120,7 @@ contract TestUpdateAPR is RewarderTest {
     }
 
     function test_UpdateAPR_CapRewardsWithMaxRwdRate() public useKnownActor(rewardManager) {
-        uint256 MAX_REWARD_RATE = 50; // 50 wei: Because rwdToken decimals are 6
+        uint128 MAX_REWARD_RATE = 50; // 50 wei: Because rwdToken decimals are 6
         Rewarder.FarmRewardConfigInput memory rewardConfig;
         address[] memory baseAssets = new address[](1);
         baseAssets[0] = USDCe;
@@ -146,7 +146,7 @@ contract TestUpdateAPR is RewarderTest {
         baseAssets[0] = DAI;
         rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 12e8,
-            maxRewardRate: UINT256_MAX,
+            maxRewardRate: type(uint128).max,
             baseTokens: baseAssets,
             nonLockupRewardPer: 5000
         });
@@ -169,7 +169,7 @@ contract TestUpdateAPR is RewarderTest {
         baseAssets[0] = DAI;
         rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 12e8,
-            maxRewardRate: UINT256_MAX,
+            maxRewardRate: type(uint128).max,
             baseTokens: baseAssets,
             nonLockupRewardPer: 5000
         });
@@ -188,7 +188,7 @@ contract TestUpdateAPR is RewarderTest {
         baseAssets[0] = USDCe;
         rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 5e9,
-            maxRewardRate: UINT256_MAX,
+            maxRewardRate: type(uint128).max,
             baseTokens: baseAssets,
             nonLockupRewardPer: 5000
         });
@@ -209,7 +209,7 @@ contract TestUpdateRewardConfig is RewarderTest {
         baseAssets[0] = USDCe;
         rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 5e9,
-            maxRewardRate: UINT256_MAX,
+            maxRewardRate: type(uint128).max,
             baseTokens: baseAssets,
             nonLockupRewardPer: 5000
         });
@@ -320,7 +320,7 @@ contract TestCalibrationRestriction is RewarderTest {
         baseAssets[0] = USDCe;
         rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 5e9,
-            maxRewardRate: UINT256_MAX,
+            maxRewardRate: type(uint128).max,
             baseTokens: baseAssets,
             nonLockupRewardPer: 5000
         });
@@ -376,7 +376,7 @@ contract TestRewardsEndTime is RewarderTest {
         baseAssets[0] = USDCe;
         rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 5e9,
-            maxRewardRate: UINT256_MAX,
+            maxRewardRate: type(uint128).max,
             baseTokens: baseAssets,
             nonLockupRewardPer: 5000
         });
@@ -402,7 +402,7 @@ contract TestFlow is RewarderTest {
         _baseTokens[1] = USDCe;
         Rewarder.FarmRewardConfigInput memory _rewardConfig = Rewarder.FarmRewardConfigInput({
             apr: 1e9,
-            maxRewardRate: type(uint256).max,
+            maxRewardRate: type(uint128).max,
             baseTokens: _baseTokens,
             nonLockupRewardPer: 5000
         });


### PR DESCRIPTION
We have added most of the validations mentioned, with a few exceptions discussed in detail below:

1. For point 4, we do not need to check for non-zero as the reward rate can be zero. To ensure a reasonable bound, we have changed the reward rate type from `uint256` to `uint128`, which will keep the reward rate within a safe range.
2. For point 5, we do not need to make any changes as we can handle any decimal places after the addition of [PR #70](https://github.com/Sperax/Demeter-Protocol/pull/70).
3. For point 8.2, we need to enforce the farm ID to be always unique. We have added a `@dev` natspec informing users to provide an appropriate farm ID based on the new farm implementation.
4. For point 9, the APR can be 0. Checking for values smaller than `APR_PRECISION * DENOMINATOR` is not required after the addition of [PR #66](https://github.com/Sperax/Demeter-Protocol/pull/66/files).
5. For point 10.1, the justification is the same as above.
6. For point 10.2, we can change the `maxRewardRate` type from `uint256` to `uint128`, thus limiting its range.

<img width="1386" alt="Screenshot 2024-06-23 at 5 38 44 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/e72c2ac6-cae9-49ff-91fb-b4ab95639804">
