### PR TITLE
Audit Fixes QS-S-2

### DIFF
--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -337,7 +337,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
                             // Get the accrued rewards for the time.
                             uint256 accRewards = _getAccRewards(iRwd, iFund, time, 0); // _alreadyAccRewardBal is 0.
                             rewardData[rewardTokens[iRwd]].accRewardBal += accRewards;
-                            fund.accRewardPerShare[iRwd] += (accRewards * PREC) / fund.totalLiquidity;
+                            fund.accRewardPerShare[iRwd] += (accRewards * PRECISION) / fund.totalLiquidity;
 
                             unchecked {
                                 ++iRwd;

--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -236,10 +236,10 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
                     uint256 accRewards = _getAccRewards(iRwd, fundId, time, accumulatedRewards[iRwd]); // accumulatedRewards is sent to consider the already accrued rewards.
                     accumulatedRewards[iRwd] += accRewards;
                     // update the accRewardPerShare for delta time.
-                    funds[fundId].accRewardPerShare[iRwd] += (accRewards * PREC) / funds[fundId].totalLiquidity;
+                    funds[fundId].accRewardPerShare[iRwd] += (accRewards * PRECISION) / funds[fundId].totalLiquidity;
                 }
                 rewards[iSub][iRwd] =
-                    ((userLiquidity * funds[fundId].accRewardPerShare[iRwd]) / PREC) - sub.rewardDebt[iRwd];
+                    ((userLiquidity * funds[fundId].accRewardPerShare[iRwd]) / PRECISION) - sub.rewardDebt[iRwd];
                 unchecked {
                     ++iRwd;
                 }
@@ -576,8 +576,8 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
             RewardFund storage fund = rewardFunds[fundId];
 
             for (uint256 iRwd; iRwd < numRewards;) {
-                // rewards = (liquidity * accRewardPerShare) / PREC - rewardDebt
-                uint256 accRewards = (userDeposit.liquidity * fund.accRewardPerShare[iRwd]) / PREC;
+                // rewards = (liquidity * accRewardPerShare) / PRECISION - rewardDebt
+                uint256 accRewards = (userDeposit.liquidity * fund.accRewardPerShare[iRwd]) / PRECISION;
                 rewards[iRwd] = accRewards - depositSubs[iSub].rewardDebt[iRwd];
                 totalRewards[iRwd] += rewards[iRwd];
 
@@ -862,7 +862,7 @@ abstract contract Farm is FarmStorage, Ownable, ReentrancyGuard, Initializable, 
 
         // Initialize user's reward debt.
         for (uint8 iRwd; iRwd < numRewards;) {
-            subscription.rewardDebt[iRwd] = (_liquidity * rewardFunds[_fundId].accRewardPerShare[iRwd]) / PREC;
+            subscription.rewardDebt[iRwd] = (_liquidity * rewardFunds[_fundId].accRewardPerShare[iRwd]) / PRECISION;
             unchecked {
                 ++iRwd;
             }

--- a/contracts/FarmRegistry.sol
+++ b/contracts/FarmRegistry.sol
@@ -30,12 +30,13 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 /// @author Sperax Foundation.
 /// @notice This contract tracks fee details, privileged deployers, deployed farms and farm deployers.
 contract FarmRegistry is OwnableUpgradeable {
+    address[] internal farms;
+    address[] internal deployerList;
+
     address public feeReceiver;
     address public feeToken;
     uint256 public feeAmount;
     uint256 public extensionFeePerDay;
-    address[] public farms;
-    address[] public deployerList;
     mapping(address => bool) public farmRegistered;
     mapping(address => bool) public deployerRegistered;
     // List of deployers for which fee won't be charged.

--- a/contracts/FarmStorage.sol
+++ b/contracts/FarmStorage.sol
@@ -33,7 +33,7 @@ abstract contract FarmStorage {
     // constants.
     uint8 public constant COMMON_FUND_ID = 0;
     uint8 public constant LOCKUP_FUND_ID = 1;
-    uint256 public constant PREC = 1e18;
+    uint256 public constant PRECISION = 1e18;
     uint256 public constant MAX_COOLDOWN_PERIOD = 30; // in days.
     uint256 public constant MAX_NUM_REWARDS = 4;
 

--- a/contracts/e721-farms/camelotV2/CamelotV2Farm.sol
+++ b/contracts/e721-farms/camelotV2/CamelotV2Farm.sol
@@ -41,6 +41,9 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
 
     // Camelot router.
     address public router;
+    address internal poolLpToken;
+    address internal poolToken0;
+    address internal poolToken1;
 
     // Events.
     event PoolRewardsCollected(address indexed recipient, uint256 indexed tokenId, uint256 grailAmt, uint256 xGrailAmt);
@@ -73,8 +76,12 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
         if (nftContract == address(0)) {
             revert InvalidCamelotPoolConfig();
         }
+        (address _lpToken,,,,,,,) = INFTPool(nftContract).getPoolInfo();
 
         router = _router;
+        poolLpToken = _lpToken;
+        poolToken0 = IPair(_lpToken).token0();
+        poolToken1 = IPair(_lpToken).token1();
         _setupFarm(_farmId, _farmStartTime, _cooldownPeriod, _rwdTokenData);
         _setupFarmExpiry(_farmStartTime, _farmRegistry);
     }
@@ -92,10 +99,11 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
             revert InvalidAmount();
         }
 
-        (address lpToken,,,,,,,) = INFTPool(nftContract).getPoolInfo();
+        // Memory variables to store storage variables.
+        address lpToken = poolLpToken;
+        address token0 = poolToken0;
+        address token1 = poolToken1;
 
-        address token0 = IPair(lpToken).token0();
-        address token1 = IPair(lpToken).token1();
         IERC20(token0).safeTransferFrom(msg.sender, address(this), _amounts[0]);
         IERC20(token1).safeTransferFrom(msg.sender, address(this), _amounts[1]);
 
@@ -136,13 +144,10 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
 
         // Withdraw liquidity from nft pool
         INFTPool(nftContract).withdrawFromPosition(depositToTokenId[_depositId], _liquidityToWithdraw);
-        (address lpToken,,,,,,,) = INFTPool(nftContract).getPoolInfo();
-        address token0 = IPair(lpToken).token0();
-        address token1 = IPair(lpToken).token1();
-        IERC20(lpToken).forceApprove(router, _liquidityToWithdraw);
+        IERC20(poolLpToken).forceApprove(router, _liquidityToWithdraw);
         IRouter(router).removeLiquidity({
-            tokenA: token0,
-            tokenB: token1,
+            tokenA: poolToken0,
+            tokenB: poolToken1,
             liquidity: _liquidityToWithdraw,
             amountAMin: _minAmounts[0],
             amountBMin: _minAmounts[1],

--- a/contracts/e721-farms/camelotV2/CamelotV2Farm.sol
+++ b/contracts/e721-farms/camelotV2/CamelotV2Farm.sol
@@ -41,9 +41,6 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
 
     // Camelot router.
     address public router;
-    address internal poolLpToken;
-    address internal poolToken0;
-    address internal poolToken1;
 
     // Events.
     event PoolRewardsCollected(address indexed recipient, uint256 indexed tokenId, uint256 grailAmt, uint256 xGrailAmt);
@@ -76,12 +73,8 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
         if (nftContract == address(0)) {
             revert InvalidCamelotPoolConfig();
         }
-        (address _lpToken,,,,,,,) = INFTPool(nftContract).getPoolInfo();
 
         router = _router;
-        poolLpToken = _lpToken;
-        poolToken0 = IPair(_lpToken).token0();
-        poolToken1 = IPair(_lpToken).token1();
         _setupFarm(_farmId, _farmStartTime, _cooldownPeriod, _rwdTokenData);
         _setupFarmExpiry(_farmStartTime, _farmRegistry);
     }
@@ -99,11 +92,10 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
             revert InvalidAmount();
         }
 
-        // Memory variables to store storage variables.
-        address lpToken = poolLpToken;
-        address token0 = poolToken0;
-        address token1 = poolToken1;
+        (address lpToken,,,,,,,) = INFTPool(nftContract).getPoolInfo();
 
+        address token0 = IPair(lpToken).token0();
+        address token1 = IPair(lpToken).token1();
         IERC20(token0).safeTransferFrom(msg.sender, address(this), _amounts[0]);
         IERC20(token1).safeTransferFrom(msg.sender, address(this), _amounts[1]);
 
@@ -144,10 +136,13 @@ contract CamelotV2Farm is E721Farm, ExpirableFarm, INFTHandler, OperableDeposit 
 
         // Withdraw liquidity from nft pool
         INFTPool(nftContract).withdrawFromPosition(depositToTokenId[_depositId], _liquidityToWithdraw);
-        IERC20(poolLpToken).forceApprove(router, _liquidityToWithdraw);
+        (address lpToken,,,,,,,) = INFTPool(nftContract).getPoolInfo();
+        address token0 = IPair(lpToken).token0();
+        address token1 = IPair(lpToken).token1();
+        IERC20(lpToken).forceApprove(router, _liquidityToWithdraw);
         IRouter(router).removeLiquidity({
-            tokenA: poolToken0,
-            tokenB: poolToken1,
+            tokenA: token0,
+            tokenB: token1,
             liquidity: _liquidityToWithdraw,
             amountAMin: _minAmounts[0],
             amountBMin: _minAmounts[1],

--- a/contracts/features/OperableDeposit.sol
+++ b/contracts/features/OperableDeposit.sol
@@ -31,8 +31,6 @@ import {Subscription, RewardFund, Deposit} from "../interfaces/DataTypes.sol";
 /// @author Sperax Foundation.
 /// @notice This contract helps in creating farms with increase/decrease deposit functionality.
 abstract contract OperableDeposit is Farm {
-    uint256 public constant PRECISION = 1e18;
-
     // Events.
     event DepositIncreased(uint256 indexed depositId, uint256 liquidity);
     event DepositDecreased(uint256 indexed depositId, uint256 liquidity);
@@ -53,7 +51,7 @@ abstract contract OperableDeposit is Farm {
             uint256[] storage _rewardDebt = _subscriptions[iSub].rewardDebt;
             uint8 _fundId = _subscriptions[iSub].fundId;
             for (uint8 iRwd; iRwd < numRewards;) {
-                _rewardDebt[iRwd] += ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PRECISION);
+                _rewardDebt[iRwd] += ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PREC);
                 unchecked {
                     ++iRwd;
                 }
@@ -77,7 +75,7 @@ abstract contract OperableDeposit is Farm {
             uint256[] storage _rewardDebt = _subscriptions[iSub].rewardDebt;
             uint8 _fundId = _subscriptions[iSub].fundId;
             for (uint8 iRwd; iRwd < numRewards;) {
-                _rewardDebt[iRwd] -= ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PRECISION);
+                _rewardDebt[iRwd] -= ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PREC);
                 unchecked {
                     ++iRwd;
                 }

--- a/contracts/features/OperableDeposit.sol
+++ b/contracts/features/OperableDeposit.sol
@@ -51,7 +51,7 @@ abstract contract OperableDeposit is Farm {
             uint256[] storage _rewardDebt = _subscriptions[iSub].rewardDebt;
             uint8 _fundId = _subscriptions[iSub].fundId;
             for (uint8 iRwd; iRwd < numRewards;) {
-                _rewardDebt[iRwd] += ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PREC);
+                _rewardDebt[iRwd] += ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PRECISION);
                 unchecked {
                     ++iRwd;
                 }
@@ -75,7 +75,7 @@ abstract contract OperableDeposit is Farm {
             uint256[] storage _rewardDebt = _subscriptions[iSub].rewardDebt;
             uint8 _fundId = _subscriptions[iSub].fundId;
             for (uint8 iRwd; iRwd < numRewards;) {
-                _rewardDebt[iRwd] -= ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PREC);
+                _rewardDebt[iRwd] -= ((_amount * _rewardFunds[_fundId].accRewardPerShare[iRwd]) / PRECISION);
                 unchecked {
                     ++iRwd;
                 }


### PR DESCRIPTION
1. We have implemented the recommended change.
2. We do agree that the implementation for these functions are quite similar, but further abstraction would result into gas cost increase for the transactions involving these functions. 
3. Merging computeRewards() and _updateFarmRewardData() is very complicated and might add-up unnecessary gas cost post abstraction. 
4. We have made deployerList and farms internal. We have kept the functions for making it easier to fetch data on frontend if required.
5. CamelotV3 and UniswapV3 farms involve different interfaces, we can try abstracting them, however it might result in unwanted complexities. Due to time constraints we will skip it for time being. 

<img width="1051" alt="Screenshot 2024-06-24 at 6 51 03 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/c2427640-45ea-43c7-8eaa-403e1d38cc3f">
