### PR TITLE
Audit Fixes QS-15

### DIFF
--- a/contracts/features/ExpirableFarm.sol
+++ b/contracts/features/ExpirableFarm.sol
@@ -43,6 +43,7 @@ abstract contract ExpirableFarm is Farm {
     event ExtensionFeeCollected(address token, uint256 extensionFee);
 
     error InvalidExtension();
+    error DurationExceeded();
     error FarmNotYetStarted();
 
     /// @notice Update the farm end time.
@@ -60,8 +61,11 @@ abstract contract ExpirableFarm is Farm {
         }
 
         uint256 newFarmEndTime = farmEndTime + _extensionDays * 1 days;
-        farmEndTime = newFarmEndTime;
+        if (newFarmEndTime > block.timestamp + MAX_EXTENSION * 1 days) {
+            revert DurationExceeded();
+        }
 
+        farmEndTime = newFarmEndTime;
         _collectExtensionFee(_extensionDays);
 
         emit FarmEndTimeUpdated(newFarmEndTime);

--- a/test/features/ExpirableFarm.t.sol
+++ b/test/features/ExpirableFarm.t.sol
@@ -207,8 +207,29 @@ abstract contract ExtendFarmDurationTest is ExpirableFarmTest {
         vm.stopPrank();
     }
 
+    function test_ExtendFarmDuration_RevertWhen_DurationExceeded() public {
+        vm.startPrank(owner);
+        uint256 maxExtensionDays = (
+            block.timestamp + ExpirableFarm(lockupFarm).MAX_EXTENSION() * 1 days
+                - ExpirableFarm(lockupFarm).farmEndTime()
+        ) / 1 days;
+        uint256 durationExceed = maxExtensionDays + 1;
+        uint256 extensionFeePerDay = FarmRegistry(FARM_REGISTRY).extensionFeePerDay();
+        address feeToken = FarmRegistry(FARM_REGISTRY).feeToken();
+        uint256 extensionFeeAmount = durationExceed * extensionFeePerDay;
+        IERC20(feeToken).approve(lockupFarm, extensionFeeAmount);
+
+        vm.expectRevert(abi.encodeWithSelector(ExpirableFarm.DurationExceeded.selector));
+        ExpirableFarm(lockupFarm).extendFarmDuration(durationExceed);
+    }
+
     function testFuzz_extendFarmDuration(bool lockup, uint256 extensionDays, uint256 farmStartTime) public {
-        vm.assume(extensionDays >= MIN_EXTENSION && extensionDays <= MAX_EXTENSION);
+        // vm.assume(extensionDays >= MIN_EXTENSION && extensionDays <= MAX_EXTENSION);
+        uint256 maxExtensionDays = (
+            block.timestamp + ExpirableFarm(lockupFarm).MAX_EXTENSION() * 1 days
+                - ExpirableFarm(lockupFarm).farmEndTime()
+        ) / 1 days;
+        extensionDays = bound(extensionDays, MIN_EXTENSION, maxExtensionDays);
         farmStartTime = bound(farmStartTime, block.timestamp + 1, type(uint64).max);
         address farm = createFarm(farmStartTime, lockup);
         vm.warp(farmStartTime + 1);


### PR DESCRIPTION
The commit fixes a bug where the farm extension duration was not being properly limited, allowing it to exceed the maximum extension limit. The code now checks if the new farm end time exceeds the maximum extension limit and reverts the transaction with the "DurationExceeded" error if it does. This ensures that the farm extension duration stays within the allowed range.
 <img width="1033" alt="Screenshot 2024-06-26 at 4 30 01 PM" src="https://github.com/Sperax/Demeter-Protocol/assets/45873074/d7b5a549-3e47-4509-9184-f4cf480f1034">
