### PR TITLE
Audit Fixes: QS-S-5

### DIFF
--- a/contracts/features/ExpirableFarm.sol
+++ b/contracts/features/ExpirableFarm.sol
@@ -83,6 +83,7 @@ abstract contract ExpirableFarm is Farm {
             : _farmEndTime - (currentFarmStartTime - _newStartTime);
 
         farmEndTime = _farmEndTime;
+
         emit FarmEndTimeUpdated(_farmEndTime);
     }
 

--- a/contracts/features/ExpirableFarm.sol
+++ b/contracts/features/ExpirableFarm.sol
@@ -81,6 +81,7 @@ abstract contract ExpirableFarm is Farm {
         _farmEndTime = (_newStartTime > currentFarmStartTime)
             ? _farmEndTime + (_newStartTime - currentFarmStartTime)
             : _farmEndTime - (currentFarmStartTime - _newStartTime);
+
         farmEndTime = _farmEndTime;
         emit FarmEndTimeUpdated(_farmEndTime);
     }

--- a/contracts/features/ExpirableFarm.sol
+++ b/contracts/features/ExpirableFarm.sol
@@ -77,9 +77,12 @@ abstract contract ExpirableFarm is Farm {
 
         super.updateFarmStartTime(_newStartTime);
 
-        farmEndTime = (_newStartTime > currentFarmStartTime)
-            ? farmEndTime + (_newStartTime - currentFarmStartTime)
-            : farmEndTime - (currentFarmStartTime - _newStartTime);
+        uint256 _farmEndTime = farmEndTime;
+        _farmEndTime = (_newStartTime > currentFarmStartTime)
+            ? _farmEndTime + (_newStartTime - currentFarmStartTime)
+            : _farmEndTime - (currentFarmStartTime - _newStartTime);
+        farmEndTime = _farmEndTime;
+        emit FarmEndTimeUpdated(_farmEndTime);
     }
 
     /// @notice Returns bool status if farm is open.

--- a/test/features/ExpirableFarm.t.sol
+++ b/test/features/ExpirableFarm.t.sol
@@ -94,6 +94,7 @@ abstract contract UpdateFarmStartTimeWithExpiryTest is ExpirableFarmTest {
 
         address farm = createFarm(initialStartTime, lockup);
         uint256 farmEndTimeBeforeUpdate = ExpirableFarm(farm).farmEndTime();
+        uint256 farmStartTime = ExpirableFarm(farm).farmStartTime();
         uint256 timeDelta;
 
         if (newStartTime > initialStartTime) {
@@ -101,10 +102,14 @@ abstract contract UpdateFarmStartTimeWithExpiryTest is ExpirableFarmTest {
         } else if (newStartTime < initialStartTime) {
             timeDelta = initialStartTime - newStartTime;
         }
-
+        uint256 newEndTime = (newStartTime > farmStartTime)
+            ? farmEndTimeBeforeUpdate + (newStartTime - farmStartTime)
+            : farmEndTimeBeforeUpdate - (farmStartTime - newStartTime);
         vm.startPrank(owner);
         vm.expectEmit(address(farm));
         emit FarmStartTimeUpdated(newStartTime);
+        vm.expectEmit(address(farm));
+        emit FarmEndTimeUpdated(newEndTime);
 
         ExpirableFarm(farm).updateFarmStartTime(newStartTime);
         vm.stopPrank();


### PR DESCRIPTION
Added emit `FarmEndTimeUpdated` in `updateFarmStartTime`.

![Screenshot 2024-06-26 at 16 43 50](https://github.com/Sperax/Demeter-Protocol/assets/140178288/9d02eac1-d54a-45bf-92c1-c87eadac416b)